### PR TITLE
feat(http-client): Add parameters argument to get

### DIFF
--- a/src/http-client.js
+++ b/src/http-client.js
@@ -14,8 +14,8 @@ export class HttpClient {
     return requestMessage.send(this, progressCallback);
   }
 
-  get(uri){
-    return this.send(new HttpRequestMessage('GET', join(this.baseUrl, uri)).withHeaders(this.defaultRequestHeaders));
+  get(uri, params){
+    return this.send(new HttpRequestMessage('GET', join(this.baseUrl, uri)).withParams(params).withHeaders(this.defaultRequestHeaders));
   }
 
   put(uri, content, replacer){

--- a/src/http-request-message.js
+++ b/src/http-request-message.js
@@ -6,6 +6,7 @@ export class HttpRequestMessage {
     this.method = method;
     this.uri = uri;
     this.content = content;
+    this.params = {};
     this.headers = new Headers();
     this.responseType = 'json'; //text, arraybuffer, blob, document
     this.replacer = replacer;
@@ -16,8 +17,13 @@ export class HttpRequestMessage {
     return this;
   }
 
-  configureXHR(xhr){
-    xhr.open(this.method, this.uri, true);
+  withParams(params){
+    this.params = params || {};
+    return this;
+  }
+
+  configureXHR(xhr, params){
+    xhr.open(this.method, buildQueryString(this.uri, this.params), true);
     xhr.responseType = this.responseType;
     this.headers.configureXHR(xhr);
   }
@@ -82,4 +88,12 @@ export class HttpRequestMessage {
       xhr.send(this.formatContent());
     });
   }
+}
+
+function buildQueryString(uri, parameters){
+  if (!parameters || !Object.keys(parameters).length) return uri;
+
+  return String.prototype.concat.call(uri, '?', Object.keys(parameters).map((each) => {
+    return encodeURIComponent(each) + '=' + encodeURIComponent(parameters[each]);
+  }).join('&'));
 }

--- a/test/http-client.spec.js
+++ b/test/http-client.spec.js
@@ -42,6 +42,22 @@ describe('http client', () => {
         expect(request.requestHeaders['Authorization']).toBe('bearer 123');
       });
 
+      it('should add parameters object as a query string', () => {
+        var client = new HttpClient(baseUrl);
+        var params = {
+          one: "one",
+          two: "two",
+          three: 3
+        };
+
+        client.get('path/with/params', params);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+
+        expect(request.url).toBe(`${baseUrl}path/with/params?one=one&two=two&three=3`);
+        expect(request.method).toBe('GET');
+        expect(request.data()).toEqual({});
+      });
     });
 
     describe('response', () => {


### PR DESCRIPTION
Get request now accepts a parameters object and builds a query string based on its key/value pairs. Signature is now get(uri, params).

Fixes #4.