### PR TITLE
fix(event): switch from hook to event

### DIFF
--- a/src/http-client.js
+++ b/src/http-client.js
@@ -14,8 +14,9 @@ function trackRequestEnd(client, processor){
   client.pendingRequests.splice(index, 1);
   client.isRequesting = client.pendingRequests.length > 0;
 
-  if(!client.isRequesting && client.onRequestsComplete){
-    client.onRequestsComplete();
+  if(!client.isRequesting){
+    var evt = new window.CustomEvent('aurelia-http-client-requests-drained', { bubbles: true, cancelable: true });
+    setTimeout(() => document.dispatchEvent(evt), 1);
   }
 }
 


### PR DESCRIPTION
fix(event): switch from hook to event

If all http-client requests are drained, trigger an event instead of
calling a method. Reason is that this way E2E tests have no dependency
on the framework implementation