### PR TITLE
fix(request-builder): rename baseUrl to baseUri for consistency

### DIFF
--- a/src/request-builder.js
+++ b/src/request-builder.js
@@ -130,9 +130,9 @@ export class RequestBuilder {
 	}
 }
 
-RequestBuilder.addHelper('withBaseUrl', function(baseUrl){
+RequestBuilder.addHelper('withBaseUri', function(baseUri){
 	return function(client, processor, message){
-		message.baseUrl = baseUrl;
+		message.baseUri = baseUri;
 	}
 });
 

--- a/src/request-message-processor.js
+++ b/src/request-message-processor.js
@@ -2,7 +2,7 @@ import {HttpResponseMessage} from './http-response-message';
 import {join, buildQueryString} from 'aurelia-path';
 
 function buildFullUri(message){
-  var uri = join(message.baseUrl, message.uri),
+  var uri = join(message.baseUri, message.uri),
       qs;
 
   if(message.params){

--- a/test/http-client.spec.js
+++ b/test/http-client.spec.js
@@ -4,7 +4,7 @@ import {Headers} from '../src/index';
 
 describe('http client', () => {
 
-  var baseUrl = "http://example.com/";
+  var baseUri = "http://example.com/";
 
   beforeEach(() => {
     jasmine.Ajax.install();
@@ -20,13 +20,13 @@ describe('http client', () => {
 
       it('should make expected request', () => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUrl(baseUrl));
+          .configure(x => x.withBaseUri(baseUri));
 
         client.get('some/cool/path');
 
         var request = jasmine.Ajax.requests.mostRecent();
 
-        expect(request.url).toBe(`${baseUrl}some/cool/path`);
+        expect(request.url).toBe(`${baseUri}some/cool/path`);
         expect(request.method).toBe('GET');
         expect(request.data()).toEqual({});
       });
@@ -34,7 +34,7 @@ describe('http client', () => {
       it('should provide expected request headers', () => {
         var client = new HttpClient()
           .configure(x => {
-            x.withBaseUrl(baseUrl);
+            x.withBaseUri(baseUri);
             x.withHeader('Authorization', 'bearer 123');
           });
 
@@ -51,7 +51,7 @@ describe('http client', () => {
 
       it('should succeed on 200 response', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUrl(baseUrl));
+          .configure(x => x.withBaseUri(baseUri));
 
         client.get('some/cool/path').then(response => {
           expect(response.isSuccess).toBe(true);
@@ -65,7 +65,7 @@ describe('http client', () => {
 
       it('should retrieve correct content', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUrl(baseUrl));
+          .configure(x => x.withBaseUri(baseUri));
 
         client.get('some/cool/path').then(response => {
           expect(response.content.name).toBe('Martin');
@@ -79,7 +79,7 @@ describe('http client', () => {
 
       it('should not succeed on 500 response', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUrl(baseUrl));
+          .configure(x => x.withBaseUri(baseUri));
 
         client.get('some/cool/path').catch(response => {
           expect(response.isSuccess).toBe(false);
@@ -104,7 +104,7 @@ describe('http client', () => {
         var content = { firstName: "John", lastName: "Doe" };
         var client = new HttpClient()
           .configure(x => {
-            x.withBaseUrl(baseUrl);
+            x.withBaseUri(baseUri);
             x.withHeader('Content-Type', 'application/json');
           });
 
@@ -112,7 +112,7 @@ describe('http client', () => {
 
         var request = jasmine.Ajax.requests.mostRecent();
 
-        expect(request.url).toBe(`${baseUrl}some/cool/path`);
+        expect(request.url).toBe(`${baseUri}some/cool/path`);
         expect(request.method).toBe('PUT');
         expect(request.data()).toEqual(content);
       });
@@ -121,7 +121,7 @@ describe('http client', () => {
         var content = { firstName: "John", lastName: "Doe" };
         var client = new HttpClient()
           .configure(x => {
-            x.withBaseUrl(baseUrl);
+            x.withBaseUri(baseUri);
             x.withHeader('Content-Type', 'application/json');
           });
 
@@ -138,7 +138,7 @@ describe('http client', () => {
       it('should provide expected request headers', () => {
         var client = new HttpClient()
           .configure(x => {
-            x.withBaseUrl(baseUrl);
+            x.withBaseUri(baseUri);
             x.withHeader('Authorization', 'bearer 123');
           });
 
@@ -155,7 +155,7 @@ describe('http client', () => {
 
       it('should succeed on 200 response', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUrl(baseUrl));
+          .configure(x => x.withBaseUri(baseUri));
 
         client.get('some/cool/path').then(response => {
           expect(response.isSuccess).toBe(true);
@@ -169,7 +169,7 @@ describe('http client', () => {
 
       it('should retrieve correct content', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUrl(baseUrl));
+          .configure(x => x.withBaseUri(baseUri));
 
         client.put('some/cool/path').then(response => {
           expect(response.content.name).toBe('Martin');
@@ -183,7 +183,7 @@ describe('http client', () => {
 
       it('should not succeed on 500 response', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUrl(baseUrl));
+          .configure(x => x.withBaseUri(baseUri));
 
         client.put('some/cool/path').catch(response => {
           expect(response.isSuccess).toBe(false);
@@ -208,7 +208,7 @@ describe('http client', () => {
         var content = { firstName: "John", lastName: "Doe" };
         var client = new HttpClient()
           .configure(x => {
-            x.withBaseUrl(baseUrl);
+            x.withBaseUri(baseUri);
             x.withHeader('Content-Type', 'application/json');
           });
 
@@ -216,7 +216,7 @@ describe('http client', () => {
 
         var request = jasmine.Ajax.requests.mostRecent();
 
-        expect(request.url).toBe(`${baseUrl}some/cool/path`);
+        expect(request.url).toBe(`${baseUri}some/cool/path`);
         expect(request.method).toBe('PATCH');
         expect(request.data()).toEqual(content);
       });
@@ -225,7 +225,7 @@ describe('http client', () => {
         var content = { firstName: "John", lastName: "Doe" };
         var client = new HttpClient()
           .configure(x => {
-            x.withBaseUrl(baseUrl);
+            x.withBaseUri(baseUri);
             x.withHeader('Content-Type', 'application/json');
           });
 
@@ -242,7 +242,7 @@ describe('http client', () => {
       it('should provide expected request headers', () => {
         var client = new HttpClient()
           .configure(x => {
-            x.withBaseUrl(baseUrl);
+            x.withBaseUri(baseUri);
             x.withHeader('Authorization', 'bearer 123');
           });
 
@@ -259,7 +259,7 @@ describe('http client', () => {
 
       it('should succeed on 200 response', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUrl(baseUrl));
+          .configure(x => x.withBaseUri(baseUri));
 
         client.put('some/cool/path').then(response => {
           expect(response.isSuccess).toBe(true);
@@ -273,7 +273,7 @@ describe('http client', () => {
 
       it('should retrieve correct content', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUrl(baseUrl));
+          .configure(x => x.withBaseUri(baseUri));
 
         client.patch('some/cool/path').then(response => {
           expect(response.content.name).toBe('Martin');
@@ -287,7 +287,7 @@ describe('http client', () => {
 
       it('should not succeed on 500 response', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUrl(baseUrl));
+          .configure(x => x.withBaseUri(baseUri));
 
         client.patch('some/cool/path').catch(response => {
           expect(response.isSuccess).toBe(false);
@@ -312,7 +312,7 @@ describe('http client', () => {
         var content = { firstName: "John", lastName: "Doe" };
         var client = new HttpClient()
           .configure(x => {
-            x.withBaseUrl(baseUrl);
+            x.withBaseUri(baseUri);
             x.withHeader('Content-Type', 'application/json');
           });
 
@@ -320,7 +320,7 @@ describe('http client', () => {
 
         var request = jasmine.Ajax.requests.mostRecent();
 
-        expect(request.url).toBe(`${baseUrl}some/cool/path`);
+        expect(request.url).toBe(`${baseUri}some/cool/path`);
         expect(request.method).toBe('POST');
         expect(request.data()).toEqual(content);
       });
@@ -329,7 +329,7 @@ describe('http client', () => {
         var content = { firstName: "John", lastName: "Doe" };
         var client = new HttpClient()
           .configure(x => {
-            x.withBaseUrl(baseUrl);
+            x.withBaseUri(baseUri);
             x.withHeader('Content-Type', 'application/json');
           });
 
@@ -346,7 +346,7 @@ describe('http client', () => {
       it('should provide expected request headers', () => {
         var client = new HttpClient()
           .configure(x => {
-            x.withBaseUrl(baseUrl);
+            x.withBaseUri(baseUri);
             x.withHeader('Authorization', 'bearer 123');
           });
 
@@ -363,7 +363,7 @@ describe('http client', () => {
 
       it('should succeed on 201 response', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUrl(baseUrl));
+          .configure(x => x.withBaseUri(baseUri));
 
         client.post('some/cool/path').then(response => {
           expect(response.isSuccess).toBe(true);
@@ -377,7 +377,7 @@ describe('http client', () => {
 
       it('should retrieve correct content', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUrl(baseUrl));
+          .configure(x => x.withBaseUri(baseUri));
 
         client.post('some/cool/path').then(response => {
           expect(response.content.name).toBe('Martin');
@@ -391,7 +391,7 @@ describe('http client', () => {
 
       it('should not succeed on 500 response', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUrl(baseUrl));
+          .configure(x => x.withBaseUri(baseUri));
 
         client.post('some/cool/path').catch(response => {
           expect(response.isSuccess).toBe(false);
@@ -413,13 +413,13 @@ describe('http client', () => {
 
       it('should make expected request', () => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUrl(baseUrl));
+          .configure(x => x.withBaseUri(baseUri));
 
         client.delete('some/cool/path');
 
         var request = jasmine.Ajax.requests.mostRecent();
 
-        expect(request.url).toBe(`${baseUrl}some/cool/path`);
+        expect(request.url).toBe(`${baseUri}some/cool/path`);
         expect(request.method).toBe('DELETE');
         expect(request.data()).toEqual({});
       });
@@ -427,7 +427,7 @@ describe('http client', () => {
       it('should provide expected request headers', () => {
         var client = new HttpClient()
           .configure(x => {
-            x.withBaseUrl(baseUrl);
+            x.withBaseUri(baseUri);
             x.withHeader('Authorization', 'bearer 123');
           });
 
@@ -444,7 +444,7 @@ describe('http client', () => {
 
       it('should succeed on 200 response', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUrl(baseUrl));
+          .configure(x => x.withBaseUri(baseUri));
 
         client.delete('some/cool/path').then(response => {
           expect(response.isSuccess).toBe(true);
@@ -458,7 +458,7 @@ describe('http client', () => {
 
       it('should not succeed on 500 response', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUrl(baseUrl));
+          .configure(x => x.withBaseUri(baseUri));
 
         client.delete('some/cool/path').catch(response => {
           expect(response.isSuccess).toBe(false);

--- a/test/request-message-processor.spec.js
+++ b/test/request-message-processor.spec.js
@@ -39,7 +39,7 @@ describe("Request message processor", () => {
       message = {
         method: 'get',
         params: [],
-        baseUrl: '',
+        baseUri: '',
         uri: 'some/uri',
         content: {},
         responseType: "test",
@@ -63,8 +63,8 @@ describe("Request message processor", () => {
       expect(sendSpy).toHaveBeenCalledWith(message.content);
     });
 
-    it("will combine the message baseUrl and message uri and set it to the fullUri", () => {
-      message.baseUrl = "/the/base";
+    it("will combine the message baseUri and message uri and set it to the fullUri", () => {
+      message.baseUri = "/the/base";
       message.uri = "and/the/path";
 
       reqProcessor.process(client, message);


### PR DESCRIPTION
This change renames baseUrl and withBaseUrl to baseUri and withBaseUri for consistency with the rest of the project.

This is a breaking API change. To update code, replace uses of `RequestBuilder.withBaseUrl()` with `RequestBuilder.withBaseUri()`.