### PR TITLE
feat(http-client): content-type detection

### DIFF
--- a/src/http-response-message.js
+++ b/src/http-response-message.js
@@ -1,3 +1,4 @@
+/*jshint -W093 */
 import {Headers} from './headers';
 
 export class HttpResponseMessage {
@@ -7,14 +8,27 @@ export class HttpResponseMessage {
     this.response = xhr.response;
     this.isSuccess = xhr.status >= 200 && xhr.status < 400;
     this.statusText = xhr.statusText;
-    this.responseType = responseType;
     this.reviver = reviver;
+    this.mimeType = null;
 
     if(xhr.getAllResponseHeaders){
-      this.headers = Headers.parse(xhr.getAllResponseHeaders());
+      try{
+        this.headers = Headers.parse(xhr.getAllResponseHeaders());
+      }catch(err){
+        //if this fails it means the xhr was a mock object so the `requestHeaders` property should be used
+        if(xhr.requestHeaders) this.headers = { headers:xhr.requestHeaders };
+      }
     }else {
       this.headers = new Headers();
     }
+
+    var contentType;
+    if(this.headers && this.headers.headers) contentType = this.headers.headers["Content-Type"];
+    if(contentType) {
+      this.mimeType = responseType = contentType.split(";")[0];
+      if(mimeTypes.hasOwnProperty(this.mimeType)) responseType = mimeTypes[this.mimeType];
+    }
+    this.responseType = responseType;
   }
 
   get content(){
@@ -45,3 +59,31 @@ export class HttpResponseMessage {
     }
   }
 }
+
+/**
+ * MimeTypes mapped to responseTypes
+ *
+ * @type {Object}
+ */
+export var mimeTypes = {
+  "text/html": "html",
+  "text/javascript": "js",
+  "application/javascript": "js",
+  "text/json": "json",
+  "application/json": "json",
+  "application/rss+xml": "rss",
+  "application/atom+xml": "atom",
+  "application/xhtml+xml": "xhtml",
+  "text/markdown": "md",
+  "text/xml": "xml",
+  "text/mathml": "mml",
+  "application/xml": "xml",
+  "text/yml": "yml",
+  "text/csv": "csv",
+  "text/css": "css",
+  "text/less": "less",
+  "text/stylus": "styl",
+  "text/scss": "scss",
+  "text/sass": "sass",
+  "text/plain": "txt"
+};

--- a/src/http-response-message.js
+++ b/src/http-response-message.js
@@ -25,7 +25,7 @@ export class HttpResponseMessage {
     var contentType;
     if(this.headers && this.headers.headers) contentType = this.headers.headers["Content-Type"];
     if(contentType) {
-      this.mimeType = responseType = contentType.split(";")[0];
+      this.mimeType = responseType = contentType.split(";")[0].trim();
       if(mimeTypes.hasOwnProperty(this.mimeType)) responseType = mimeTypes[this.mimeType];
     }
     this.responseType = responseType;

--- a/src/request-builder.js
+++ b/src/request-builder.js
@@ -3,162 +3,162 @@ import {HttpRequestMessage} from './http-request-message';
 import {JSONPRequestMessage} from './jsonp-request-message';
 
 /**
-* A builder class allowing fluent composition of HTTP requests.
-*
-* @class RequestBuilder
-* @constructor
-*/
+ * A builder class allowing fluent composition of HTTP requests.
+ *
+ * @class RequestBuilder
+ * @constructor
+ */
 export class RequestBuilder {
-	constructor (client) {
-		this.client = client;
-		this.transformers = client.requestTransformers.slice(0);
-		this.useJsonp = false;
-	}
+  constructor(client){
+    this.client = client;
+    this.transformers = client.requestTransformers.slice(0);
+    this.useJsonp = false;
+  }
 
-	/**
-	* Adds a user-defined request transformer to the RequestBuilder.
-	*
-	* @method addHelper
-	* @param {String} name The name of the helper to add.
-	* @param {Function} fn The helper function.
-	* @chainable
-	*/
-	static addHelper(name, fn){
-		RequestBuilder.prototype[name] = function(){
-			this.transformers.push(fn.apply(this, arguments));
-			return this;
-		};
-	}
+  /**
+   * Adds a user-defined request transformer to the RequestBuilder.
+   *
+   * @method addHelper
+   * @param {String} name The name of the helper to add.
+   * @param {Function} fn The helper function.
+   * @chainable
+   */
+  static addHelper(name, fn){
+    RequestBuilder.prototype[name] = function(){
+      this.transformers.push(fn.apply(this, arguments));
+      return this;
+    };
+  }
 
-	/**
-	* Sends the request.
-	*
-	* @method send
-	* @return {Promise} A cancellable promise object.
-	*/
-	send(){
-		let message = this.useJsonp ? new JSONPRequestMessage() : new HttpRequestMessage();
-		return this.client.send(message, this.transformers);
-	}
+  /**
+   * Sends the request.
+   *
+   * @method send
+   * @return {Promise} A cancellable promise object.
+   */
+  send(){
+    let message = this.useJsonp ? new JSONPRequestMessage() : new HttpRequestMessage();
+    return this.client.send(message, this.transformers);
+  }
 }
 
 RequestBuilder.addHelper('asDelete', function(){
-	return function(client, processor, message){
-		message.method = 'DELETE';
-	};
+  return function(client, processor, message){
+    message.method = 'DELETE';
+  };
 });
 
 RequestBuilder.addHelper('asGet', function(){
-	return function(client, processor, message){
-		message.method = 'GET';
-	};
+  return function(client, processor, message){
+    message.method = 'GET';
+  };
 });
 
 RequestBuilder.addHelper('asHead', function(){
-	return function(client, processor, message){
-		message.method = 'HEAD';
-	};
+  return function(client, processor, message){
+    message.method = 'HEAD';
+  };
 });
 
 RequestBuilder.addHelper('asOptions', function(){
-	return function(client, processor, message){
-		message.method = 'OPTIONS';
-	};
+  return function(client, processor, message){
+    message.method = 'OPTIONS';
+  };
 });
 
 RequestBuilder.addHelper('asPatch', function(){
-	return function(client, processor, message){
-		message.method = 'PATCH';
-	};
+  return function(client, processor, message){
+    message.method = 'PATCH';
+  };
 });
 
 RequestBuilder.addHelper('asPost', function(){
-	return function(client, processor, message){
-		message.method = 'POST';
-	};
+  return function(client, processor, message){
+    message.method = 'POST';
+  };
 });
 
 RequestBuilder.addHelper('asPut', function(){
-	return function(client, processor, message){
-		message.method = 'PUT';
-	};
+  return function(client, processor, message){
+    message.method = 'PUT';
+  };
 });
 
 RequestBuilder.addHelper('asJsonp', function(callbackParameterName){
-	this.useJsonp = true;
-	return function(client, processor, message){
-		message.callbackParameterName =  callbackParameterName;
-	};
+  this.useJsonp = true;
+  return function(client, processor, message){
+    message.callbackParameterName = callbackParameterName;
+  };
 });
 
 RequestBuilder.addHelper('withUri', function(uri){
-	return function(client, processor, message){
-		message.uri = uri;
-	};
+  return function(client, processor, message){
+    message.uri = uri;
+  };
 });
 
 RequestBuilder.addHelper('withContent', function(content){
-	return function(client, processor, message){
-		message.content = content;
-	};
+  return function(client, processor, message){
+    message.content = content;
+  };
 });
 
 RequestBuilder.addHelper('withBaseUri', function(baseUri){
-	return function(client, processor, message){
-		message.baseUri = baseUri;
-	}
+  return function(client, processor, message){
+    message.baseUri = baseUri;
+  };
 });
 
 RequestBuilder.addHelper('withParams', function(params){
-	return function(client, processor, message){
-		message.params = params;
-	}
+  return function(client, processor, message){
+    message.params = params;
+  };
 });
 
 RequestBuilder.addHelper('withResponseType', function(responseType){
-	return function(client, processor, message){
-		message.responseType = responseType;
-	}
+  return function(client, processor, message){
+    message.responseType = responseType;
+  };
 });
 
 RequestBuilder.addHelper('withTimeout', function(timeout){
-	return function(client, processor, message){
-		message.timeout = timeout;
-	}
+  return function(client, processor, message){
+    message.timeout = timeout;
+  };
 });
 
 RequestBuilder.addHelper('withHeader', function(key, value){
-	return function(client, processor, message){
-		message.headers.add(key, value);
-	}
+  return function(client, processor, message){
+    message.headers.add(key, value);
+  };
 });
 
 RequestBuilder.addHelper('withCredentials', function(value){
-	return function(client, processor, message){
-		message.withCredentials = value;
-	}
+  return function(client, processor, message){
+    message.withCredentials = value;
+  };
 });
 
 RequestBuilder.addHelper('withReviver', function(reviver){
-	return function(client, processor, message){
-		message.reviver = reviver;
-	}
+  return function(client, processor, message){
+    message.reviver = reviver;
+  };
 });
 
 RequestBuilder.addHelper('withReplacer', function(replacer){
-	return function(client, processor, message){
-		message.replacer = replacer;
-	}
+  return function(client, processor, message){
+    message.replacer = replacer;
+  };
 });
 
 RequestBuilder.addHelper('withProgressCallback', function(progressCallback){
-	return function(client, processor, message){
-		message.progressCallback = progressCallback;
-	}
+  return function(client, processor, message){
+    message.progressCallback = progressCallback;
+  };
 });
 
 RequestBuilder.addHelper('withCallbackParameterName', function(callbackParameterName){
-	return function(client, processor, message){
-		message.callbackParameterName = callbackParameterName;
-	}
+  return function(client, processor, message){
+    message.callbackParameterName = callbackParameterName;
+  };
 });


### PR DESCRIPTION
Detects the content-type in the response header and sets the `responseType` accordingly. The `mimeType` property is also added and holds the mimetype extracted from the content-type.

fixes: https://github.com/aurelia/http-client/issues/34