### PR TITLE
refactor(all): rename uses of "URI" to "URL" for consistency with the rest of Aurelia

### DIFF
--- a/src/http-client.js
+++ b/src/http-client.js
@@ -55,14 +55,14 @@ export class HttpClient {
    * Returns a new RequestBuilder for this HttpClient instance that can be used to build and send HTTP requests.
    *
    * @method createRequest
-   * @param uri The target URI.
+   * @param url The target URL.
    * @type RequestBuilder
    */
-  createRequest(uri){
+  createRequest(url){
     let builder = new RequestBuilder(this);
 
-    if(uri) {
-      builder.withUri(uri);
+    if(url) {
+      builder.withUrl(url);
     }
 
     return builder;
@@ -112,90 +112,90 @@ export class HttpClient {
    * Sends an HTTP DELETE request.
    *
    * @method delete
-   * @param {String} uri The target URI.
+   * @param {String} url The target URL.
    * @return {Promise} A cancellable promise object.
    */
-  delete(uri){
-    return this.createRequest(uri).asDelete().send();
+  delete(url){
+    return this.createRequest(url).asDelete().send();
   }
 
   /**
    * Sends an HTTP GET request.
    *
    * @method get
-   * @param {String} uri The target URI.
+   * @param {String} url The target URL.
    * @return {Promise} A cancellable promise object.
    */
-  get(uri){
-    return this.createRequest(uri).asGet().send();
+  get(url){
+    return this.createRequest(url).asGet().send();
   }
 
   /**
    * Sends an HTTP HEAD request.
    *
    * @method head
-   * @param {String} uri The target URI.
+   * @param {String} url The target URL.
    * @return {Promise} A cancellable promise object.
    */
-  head(uri){
-    return this.createRequest(uri).asHead().send();
+  head(url){
+    return this.createRequest(url).asHead().send();
   }
 
   /**
    * Sends a JSONP request.
    *
    * @method jsonp
-   * @param {String} uri The target URI.
+   * @param {String} url The target URL.
    * @return {Promise} A cancellable promise object.
    */
-  jsonp(uri, callbackParameterName='jsoncallback'){
-    return this.createRequest(uri).asJsonp(callbackParameterName).send();
+  jsonp(url, callbackParameterName='jsoncallback'){
+    return this.createRequest(url).asJsonp(callbackParameterName).send();
   }
 
   /**
    * Sends an HTTP OPTIONS request.
    *
    * @method options
-   * @param {String} uri The target URI.
+   * @param {String} url The target URL.
    * @return {Promise} A cancellable promise object.
    */
-  options(uri){
-    return this.createRequest(uri).asOptions().send();
+  options(url){
+    return this.createRequest(url).asOptions().send();
   }
 
   /**
    * Sends an HTTP PUT request.
    *
    * @method put
-   * @param {String} uri The target URI.
-   * @param {Object} uri The request payload.
+   * @param {String} url The target URL.
+   * @param {Object} url The request payload.
    * @return {Promise} A cancellable promise object.
    */
-  put(uri, content){
-    return this.createRequest(uri).asPut().withContent(content).send();
+  put(url, content){
+    return this.createRequest(url).asPut().withContent(content).send();
   }
 
   /**
    * Sends an HTTP PATCH request.
    *
    * @method patch
-   * @param {String} uri The target URI.
-   * @param {Object} uri The request payload.
+   * @param {String} url The target URL.
+   * @param {Object} url The request payload.
    * @return {Promise} A cancellable promise object.
    */
-  patch(uri, content){
-    return this.createRequest(uri).asPatch().withContent(content).send();
+  patch(url, content){
+    return this.createRequest(url).asPatch().withContent(content).send();
   }
 
   /**
    * Sends an HTTP POST request.
    *
    * @method post
-   * @param {String} uri The target URI.
-   * @param {Object} uri The request payload.
+   * @param {String} url The target URL.
+   * @param {Object} url The request payload.
    * @return {Promise} A cancellable promise object.
    */
-  post(uri, content){
-    return this.createRequest(uri).asPost().withContent(content).send();
+  post(url, content){
+    return this.createRequest(url).asPost().withContent(content).send();
   }
 }

--- a/src/http-request-message.js
+++ b/src/http-request-message.js
@@ -10,9 +10,9 @@ import {
 } from './transformers';
 
 export class HttpRequestMessage {
-  constructor(method, uri, content, headers){
+  constructor(method, url, content, headers){
     this.method = method;
-    this.uri = uri;
+    this.url = url;
     this.content = content;
     this.headers = headers || new Headers();
     this.responseType = 'json'; //text, arraybuffer, blob, document

--- a/src/jsonp-request-message.js
+++ b/src/jsonp-request-message.js
@@ -6,9 +6,9 @@ import {
 } from './transformers';
 
 export class JSONPRequestMessage {
-  constructor(uri, callbackParameterName){
+  constructor(url, callbackParameterName){
     this.method = 'JSONP';
-    this.uri = uri;
+    this.url = url;
     this.content = undefined;
     this.headers = new Headers();
     this.responseType = 'jsonp';
@@ -17,14 +17,14 @@ export class JSONPRequestMessage {
 }
 
 class JSONPXHR {
-  open(method, uri){
+  open(method, url){
     this.method = method;
-    this.uri = uri;
+    this.url = url;
     this.callbackName = 'jsonp_callback_' + Math.round(100000 * Math.random());
   }
 
   send(){
-    var uri = this.uri + (this.uri.indexOf('?') >= 0 ? '&' : '?') + this.callbackParameterName + '=' + this.callbackName;
+    var url = this.url + (this.url.indexOf('?') >= 0 ? '&' : '?') + this.callbackParameterName + '=' + this.callbackName;
 
     window[this.callbackName] = (data) => {
       delete window[this.callbackName];
@@ -39,7 +39,7 @@ class JSONPXHR {
     };
 
     var script = document.createElement('script');
-    script.src = uri;
+    script.src = url;
     document.body.appendChild(script);
 
     if(this.timeout !== undefined){

--- a/src/request-builder.js
+++ b/src/request-builder.js
@@ -91,9 +91,9 @@ RequestBuilder.addHelper('asJsonp', function(callbackParameterName){
   };
 });
 
-RequestBuilder.addHelper('withUri', function(uri){
+RequestBuilder.addHelper('withUrl', function(url){
   return function(client, processor, message){
-    message.uri = uri;
+    message.url = url;
   };
 });
 
@@ -103,9 +103,9 @@ RequestBuilder.addHelper('withContent', function(content){
   };
 });
 
-RequestBuilder.addHelper('withBaseUri', function(baseUri){
+RequestBuilder.addHelper('withBaseUrl', function(baseUrl){
   return function(client, processor, message){
-    message.baseUri = baseUri;
+    message.baseUrl = baseUrl;
   };
 });
 

--- a/src/request-message-processor.js
+++ b/src/request-message-processor.js
@@ -2,16 +2,16 @@ import core from 'core-js';
 import {HttpResponseMessage} from './http-response-message';
 import {join, buildQueryString} from 'aurelia-path';
 
-function buildFullUri(message){
-  var uri = join(message.baseUri, message.uri),
+function buildFullUrl(message){
+  var url = join(message.baseUrl, message.url),
       qs;
 
   if(message.params){
     qs = buildQueryString(message.params);
-    uri = qs ? `${uri}?${qs}` : uri;
+    url = qs ? `${url}?${qs}` : url;
   }
 
-  message.fullUri = uri;
+  message.fullUrl = url;
 }
 
 export class RequestMessageProcessor {
@@ -33,8 +33,8 @@ export class RequestMessageProcessor {
           transformers = this.transformers,
           i, ii;
 
-      buildFullUri(message);
-      xhr.open(message.method, message.fullUri, true);
+      buildFullUrl(message);
+      xhr.open(message.method, message.fullUrl, true);
 
       for(i = 0, ii = transformers.length; i < ii; ++i){
         transformers[i](client, this, message, xhr);

--- a/test/http-client.spec.js
+++ b/test/http-client.spec.js
@@ -4,7 +4,7 @@ import {Headers} from '../src/index';
 
 describe('http client', () => {
 
-  var baseUri = "http://example.com/";
+  var baseUrl = "http://example.com/";
 
   beforeEach(() => {
     jasmine.Ajax.install();
@@ -20,13 +20,13 @@ describe('http client', () => {
 
       it('should make expected request', () => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUri(baseUri));
+          .configure(x => x.withBaseUrl(baseUrl));
 
         client.get('some/cool/path');
 
         var request = jasmine.Ajax.requests.mostRecent();
 
-        expect(request.url).toBe(`${baseUri}some/cool/path`);
+        expect(request.url).toBe(`${baseUrl}some/cool/path`);
         expect(request.method).toBe('GET');
         expect(request.data()).toEqual({});
       });
@@ -34,7 +34,7 @@ describe('http client', () => {
       it('should provide expected request headers', () => {
         var client = new HttpClient()
           .configure(x => {
-            x.withBaseUri(baseUri);
+            x.withBaseUrl(baseUrl);
             x.withHeader('Authorization', 'bearer 123');
           });
 
@@ -51,7 +51,7 @@ describe('http client', () => {
 
       it('should succeed on 200 response', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUri(baseUri));
+          .configure(x => x.withBaseUrl(baseUrl));
 
         client.get('some/cool/path').then(response => {
           expect(response.isSuccess).toBe(true);
@@ -65,7 +65,7 @@ describe('http client', () => {
 
       it('should retrieve correct content', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUri(baseUri));
+          .configure(x => x.withBaseUrl(baseUrl));
 
         client.get('some/cool/path').then(response => {
           expect(response.content.name).toBe('Martin');
@@ -79,7 +79,7 @@ describe('http client', () => {
 
       it('should not succeed on 500 response', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUri(baseUri));
+          .configure(x => x.withBaseUrl(baseUrl));
 
         client.get('some/cool/path').catch(response => {
           expect(response.isSuccess).toBe(false);
@@ -104,7 +104,7 @@ describe('http client', () => {
         var content = { firstName: "John", lastName: "Doe" };
         var client = new HttpClient()
           .configure(x => {
-            x.withBaseUri(baseUri);
+            x.withBaseUrl(baseUrl);
             x.withHeader('Content-Type', 'application/json');
           });
 
@@ -112,7 +112,7 @@ describe('http client', () => {
 
         var request = jasmine.Ajax.requests.mostRecent();
 
-        expect(request.url).toBe(`${baseUri}some/cool/path`);
+        expect(request.url).toBe(`${baseUrl}some/cool/path`);
         expect(request.method).toBe('PUT');
         expect(request.data()).toEqual(content);
       });
@@ -121,7 +121,7 @@ describe('http client', () => {
         var content = { firstName: "John", lastName: "Doe" };
         var client = new HttpClient()
           .configure(x => {
-            x.withBaseUri(baseUri);
+            x.withBaseUrl(baseUrl);
             x.withHeader('Content-Type', 'application/json');
           });
 
@@ -140,7 +140,7 @@ describe('http client', () => {
       it('should provide expected request headers', () => {
         var client = new HttpClient()
           .configure(x => {
-            x.withBaseUri(baseUri);
+            x.withBaseUrl(baseUrl);
             x.withHeader('Authorization', 'bearer 123');
           });
 
@@ -157,7 +157,7 @@ describe('http client', () => {
 
       it('should succeed on 200 response', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUri(baseUri));
+          .configure(x => x.withBaseUrl(baseUrl));
 
         client.get('some/cool/path').then(response => {
           expect(response.isSuccess).toBe(true);
@@ -171,7 +171,7 @@ describe('http client', () => {
 
       it('should retrieve correct content', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUri(baseUri));
+          .configure(x => x.withBaseUrl(baseUrl));
 
         client.put('some/cool/path').then(response => {
           expect(response.content.name).toBe('Martin');
@@ -185,7 +185,7 @@ describe('http client', () => {
 
       it('should not succeed on 500 response', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUri(baseUri));
+          .configure(x => x.withBaseUrl(baseUrl));
 
         client.put('some/cool/path').catch(response => {
           expect(response.isSuccess).toBe(false);
@@ -210,7 +210,7 @@ describe('http client', () => {
         var content = { firstName: "John", lastName: "Doe" };
         var client = new HttpClient()
           .configure(x => {
-            x.withBaseUri(baseUri);
+            x.withBaseUrl(baseUrl);
             x.withHeader('Content-Type', 'application/json');
           });
 
@@ -218,7 +218,7 @@ describe('http client', () => {
 
         var request = jasmine.Ajax.requests.mostRecent();
 
-        expect(request.url).toBe(`${baseUri}some/cool/path`);
+        expect(request.url).toBe(`${baseUrl}some/cool/path`);
         expect(request.method).toBe('PATCH');
         expect(request.data()).toEqual(content);
       });
@@ -227,7 +227,7 @@ describe('http client', () => {
         var content = { firstName: "John", lastName: "Doe" };
         var client = new HttpClient()
           .configure(x => {
-            x.withBaseUri(baseUri);
+            x.withBaseUrl(baseUrl);
             x.withHeader('Content-Type', 'application/json');
           });
 
@@ -246,7 +246,7 @@ describe('http client', () => {
       it('should provide expected request headers', () => {
         var client = new HttpClient()
           .configure(x => {
-            x.withBaseUri(baseUri);
+            x.withBaseUrl(baseUrl);
             x.withHeader('Authorization', 'bearer 123');
           });
 
@@ -263,7 +263,7 @@ describe('http client', () => {
 
       it('should succeed on 200 response', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUri(baseUri));
+          .configure(x => x.withBaseUrl(baseUrl));
 
         client.put('some/cool/path').then(response => {
           expect(response.isSuccess).toBe(true);
@@ -277,7 +277,7 @@ describe('http client', () => {
 
       it('should retrieve correct content', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUri(baseUri));
+          .configure(x => x.withBaseUrl(baseUrl));
 
         client.patch('some/cool/path').then(response => {
           expect(response.content.name).toBe('Martin');
@@ -291,7 +291,7 @@ describe('http client', () => {
 
       it('should not succeed on 500 response', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUri(baseUri));
+          .configure(x => x.withBaseUrl(baseUrl));
 
         client.patch('some/cool/path').catch(response => {
           expect(response.isSuccess).toBe(false);
@@ -316,7 +316,7 @@ describe('http client', () => {
         var content = { firstName: "John", lastName: "Doe" };
         var client = new HttpClient()
           .configure(x => {
-            x.withBaseUri(baseUri);
+            x.withBaseUrl(baseUrl);
             x.withHeader('Content-Type', 'application/json');
           });
 
@@ -324,7 +324,7 @@ describe('http client', () => {
 
         var request = jasmine.Ajax.requests.mostRecent();
 
-        expect(request.url).toBe(`${baseUri}some/cool/path`);
+        expect(request.url).toBe(`${baseUrl}some/cool/path`);
         expect(request.method).toBe('POST');
         expect(request.data()).toEqual(content);
       });
@@ -333,7 +333,7 @@ describe('http client', () => {
         var content = { firstName: "John", lastName: "Doe" };
         var client = new HttpClient()
           .configure(x => {
-            x.withBaseUri(baseUri);
+            x.withBaseUrl(baseUrl);
             x.withHeader('Content-Type', 'application/json');
           });
 
@@ -352,7 +352,7 @@ describe('http client', () => {
       it('should provide expected request headers', () => {
         var client = new HttpClient()
           .configure(x => {
-            x.withBaseUri(baseUri);
+            x.withBaseUrl(baseUrl);
             x.withHeader('Authorization', 'bearer 123');
           });
 
@@ -369,7 +369,7 @@ describe('http client', () => {
 
       it('should succeed on 201 response', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUri(baseUri));
+          .configure(x => x.withBaseUrl(baseUrl));
 
         client.post('some/cool/path').then(response => {
           expect(response.isSuccess).toBe(true);
@@ -383,7 +383,7 @@ describe('http client', () => {
 
       it('should retrieve correct content', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUri(baseUri));
+          .configure(x => x.withBaseUrl(baseUrl));
 
         client.post('some/cool/path').then(response => {
           expect(response.content.name).toBe('Martin');
@@ -397,7 +397,7 @@ describe('http client', () => {
 
       it('should not succeed on 500 response', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUri(baseUri));
+          .configure(x => x.withBaseUrl(baseUrl));
 
         client.post('some/cool/path').catch(response => {
           expect(response.isSuccess).toBe(false);
@@ -419,13 +419,13 @@ describe('http client', () => {
 
       it('should make expected request', () => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUri(baseUri));
+          .configure(x => x.withBaseUrl(baseUrl));
 
         client.delete('some/cool/path');
 
         var request = jasmine.Ajax.requests.mostRecent();
 
-        expect(request.url).toBe(`${baseUri}some/cool/path`);
+        expect(request.url).toBe(`${baseUrl}some/cool/path`);
         expect(request.method).toBe('DELETE');
         expect(request.data()).toEqual({});
       });
@@ -433,7 +433,7 @@ describe('http client', () => {
       it('should provide expected request headers', () => {
         var client = new HttpClient()
           .configure(x => {
-            x.withBaseUri(baseUri);
+            x.withBaseUrl(baseUrl);
             x.withHeader('Authorization', 'bearer 123');
           });
 
@@ -450,7 +450,7 @@ describe('http client', () => {
 
       it('should succeed on 200 response', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUri(baseUri));
+          .configure(x => x.withBaseUrl(baseUrl));
 
         client.delete('some/cool/path').then(response => {
           expect(response.isSuccess).toBe(true);
@@ -464,7 +464,7 @@ describe('http client', () => {
 
       it('should not succeed on 500 response', (done) => {
         var client = new HttpClient()
-          .configure(x => x.withBaseUri(baseUri));
+          .configure(x => x.withBaseUrl(baseUrl));
 
         client.delete('some/cool/path').catch(response => {
           expect(response.isSuccess).toBe(false);

--- a/test/http-request-message.spec.js
+++ b/test/http-request-message.spec.js
@@ -12,20 +12,20 @@ import {
 
 describe("http-request-message", () => {
 
-  it("should have a constructor that takes in the method, uri, content and headers", () => {
-    let method = {}, uri = {}, content = {}, headers = {};
-    let httpRequestMessage = new HttpRequestMessage(method, uri, content, headers);
+  it("should have a constructor that takes in the method, url, content and headers", () => {
+    let method = {}, url = {}, content = {}, headers = {};
+    let httpRequestMessage = new HttpRequestMessage(method, url, content, headers);
 
     expect(httpRequestMessage.method).toBe(method);
-    expect(httpRequestMessage.uri).toBe(uri);
+    expect(httpRequestMessage.url).toBe(url);
     expect(httpRequestMessage.content).toBe(content);
     expect(httpRequestMessage.headers).toBe(headers);
     expect(httpRequestMessage.responseType).toBe('json');
   });
 
   it("have a constructor should default the headers if not provided", () => {
-    let method = {}, uri = {}, content = {};
-    let httpRequestMessage = new HttpRequestMessage(method, uri, content);
+    let method = {}, url = {}, content = {};
+    let httpRequestMessage = new HttpRequestMessage(method, url, content);
     expect(httpRequestMessage.headers).toEqual(jasmine.any(Headers));
   });
 

--- a/test/jsonp-request-message.spec.js
+++ b/test/jsonp-request-message.spec.js
@@ -5,10 +5,10 @@ import { timeoutTransformer, callbackParameterNameTransformer } from '../src/tra
 
 describe("JSONPRequestMessage", () => {
   it("should have a constructor that correctly sets the methods and response type", () => {
-    let uri = {}, callbackName = {};
-    let jsonpRequest = new JSONPRequestMessage(uri, callbackName);
+    let url = {}, callbackName = {};
+    let jsonpRequest = new JSONPRequestMessage(url, callbackName);
     expect(jsonpRequest.method).toBe('JSONP');
-    expect(jsonpRequest.uri).toBe(uri);
+    expect(jsonpRequest.url).toBe(url);
     expect(jsonpRequest.content).toBeUndefined();
     expect(jsonpRequest.headers).toEqual(jasmine.any(Headers));
     expect(jsonpRequest.responseType).toBe('jsonp');

--- a/test/request-message-processor.spec.js
+++ b/test/request-message-processor.spec.js
@@ -39,8 +39,8 @@ describe("Request message processor", () => {
       message = {
         method: 'get',
         params: [],
-        baseUri: '',
-        uri: 'some/uri',
+        baseUrl: '',
+        url: 'some/url',
         content: {},
         responseType: "test",
         reviver: (obj) => obj
@@ -53,9 +53,9 @@ describe("Request message processor", () => {
       expect(reqProcessor.xhr).toEqual(jasmine.any(MockXhrType));
     });
 
-    it("should call xhr.open with the method, full uri and ajax set to true", () => {
+    it("should call xhr.open with the method, full url and ajax set to true", () => {
       reqProcessor.process(client, message);
-      expect(openSpy).toHaveBeenCalledWith(message.method, message.uri, true);
+      expect(openSpy).toHaveBeenCalledWith(message.method, message.url, true);
     });
 
     it("should call xhr.send with the message content", () => {
@@ -63,12 +63,12 @@ describe("Request message processor", () => {
       expect(sendSpy).toHaveBeenCalledWith(message.content);
     });
 
-    it("will combine the message baseUri and message uri and set it to the fullUri", () => {
-      message.baseUri = "/the/base";
-      message.uri = "and/the/path";
+    it("will combine the message baseUrl and message url and set it to the fullUrl", () => {
+      message.baseUrl = "/the/base";
+      message.url = "and/the/path";
 
       reqProcessor.process(client, message);
-      expect(message.fullUri).toBe("/the/base/and/the/path");
+      expect(message.fullUrl).toBe("/the/base/and/the/path");
     });
 
     it("should run through all the transformers", () => {


### PR DESCRIPTION
BREAKING CHANGE: This is a breaking API change to `HttpRequestBuilder` and `HttpRequestMessage`. To update, replace uses of `withUri`, `withBaseUri`, and `uri` with `withUrl`, `withBaseUrl`, and `url`, as appropriate.

fixes aurelia/router#54 -- All other Aurelia projects use "URL" instead of "URI".