### PR TITLE
aurelia-http-client doesn't work in IE9

### DIFF
--- a/dist/amd/headers.js
+++ b/dist/amd/headers.js
@@ -1,9 +1,9 @@
 define(['exports'], function (exports) {
   'use strict';
 
-  var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
-
   exports.__esModule = true;
+
+  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
   var Headers = (function () {
     function Headers() {

--- a/dist/amd/http-client.js
+++ b/dist/amd/http-client.js
@@ -1,11 +1,11 @@
 define(['exports', 'core-js', './headers', './request-builder', './http-request-message', './jsonp-request-message'], function (exports, _coreJs, _headers, _requestBuilder, _httpRequestMessage, _jsonpRequestMessage) {
   'use strict';
 
-  var _interopRequire = function (obj) { return obj && obj.__esModule ? obj['default'] : obj; };
-
-  var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
-
   exports.__esModule = true;
+
+  function _interopRequire(obj) { return obj && obj.__esModule ? obj['default'] : obj; }
+
+  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
   var _core = _interopRequire(_coreJs);
 

--- a/dist/amd/http-request-message.js
+++ b/dist/amd/http-request-message.js
@@ -1,10 +1,10 @@
 define(['exports', './headers', './request-message-processor', './transformers'], function (exports, _headers, _requestMessageProcessor, _transformers) {
   'use strict';
 
-  var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
-
   exports.__esModule = true;
   exports.createHttpRequestMessageProcessor = createHttpRequestMessageProcessor;
+
+  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
   var HttpRequestMessage = function HttpRequestMessage(method, url, content, headers) {
     _classCallCheck(this, HttpRequestMessage);

--- a/dist/amd/http-response-message.js
+++ b/dist/amd/http-response-message.js
@@ -1,11 +1,11 @@
 define(["exports", "./headers"], function (exports, _headers) {
   "use strict";
 
-  var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };
+  exports.__esModule = true;
 
   var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
-  exports.__esModule = true;
+  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
   var HttpResponseMessage = (function () {
     function HttpResponseMessage(requestMessage, xhr, responseType, reviver) {
@@ -13,7 +13,7 @@ define(["exports", "./headers"], function (exports, _headers) {
 
       this.requestMessage = requestMessage;
       this.statusCode = xhr.status;
-      this.response = xhr.response;
+      this.response = xhr.response || xhr.responseText;
       this.isSuccess = xhr.status >= 200 && xhr.status < 400;
       this.statusText = xhr.statusText;
       this.reviver = reviver;

--- a/dist/amd/jsonp-request-message.js
+++ b/dist/amd/jsonp-request-message.js
@@ -1,10 +1,10 @@
 define(['exports', './headers', './request-message-processor', './transformers'], function (exports, _headers, _requestMessageProcessor, _transformers) {
   'use strict';
 
-  var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
-
   exports.__esModule = true;
   exports.createJSONPRequestMessageProcessor = createJSONPRequestMessageProcessor;
+
+  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
   var JSONPRequestMessage = function JSONPRequestMessage(url, callbackParameterName) {
     _classCallCheck(this, JSONPRequestMessage);

--- a/dist/amd/request-builder.js
+++ b/dist/amd/request-builder.js
@@ -1,9 +1,9 @@
 define(['exports', 'aurelia-path', './http-request-message', './jsonp-request-message'], function (exports, _aureliaPath, _httpRequestMessage, _jsonpRequestMessage) {
   'use strict';
 
-  var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
-
   exports.__esModule = true;
+
+  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
   var RequestBuilder = (function () {
     function RequestBuilder(client) {

--- a/dist/amd/request-message-processor.js
+++ b/dist/amd/request-message-processor.js
@@ -1,11 +1,11 @@
 define(['exports', 'core-js', './http-response-message', 'aurelia-path'], function (exports, _coreJs, _httpResponseMessage, _aureliaPath) {
   'use strict';
 
-  var _interopRequire = function (obj) { return obj && obj.__esModule ? obj['default'] : obj; };
-
-  var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
-
   exports.__esModule = true;
+
+  function _interopRequire(obj) { return obj && obj.__esModule ? obj['default'] : obj; }
+
+  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
   var _core = _interopRequire(_coreJs);
 

--- a/dist/commonjs/headers.js
+++ b/dist/commonjs/headers.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
-
 exports.__esModule = true;
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
 var Headers = (function () {
   function Headers() {

--- a/dist/commonjs/http-client.js
+++ b/dist/commonjs/http-client.js
@@ -1,22 +1,22 @@
 'use strict';
 
-var _interopRequireDefault = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
-
-var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
-
 exports.__esModule = true;
 
-var _core = require('core-js');
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-var _core2 = _interopRequireDefault(_core);
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
-var _Headers = require('./headers');
+var _coreJs = require('core-js');
 
-var _RequestBuilder = require('./request-builder');
+var _coreJs2 = _interopRequireDefault(_coreJs);
 
-var _HttpRequestMessage$createHttpRequestMessageProcessor = require('./http-request-message');
+var _headers = require('./headers');
 
-var _JSONPRequestMessage$createJSONPRequestMessageProcessor = require('./jsonp-request-message');
+var _requestBuilder = require('./request-builder');
+
+var _httpRequestMessage = require('./http-request-message');
+
+var _jsonpRequestMessage = require('./jsonp-request-message');
 
 function trackRequestStart(client, processor) {
   client.pendingRequests.push(processor);
@@ -43,21 +43,21 @@ var HttpClient = (function () {
 
     this.requestTransformers = [];
     this.requestProcessorFactories = new Map();
-    this.requestProcessorFactories.set(_HttpRequestMessage$createHttpRequestMessageProcessor.HttpRequestMessage, _HttpRequestMessage$createHttpRequestMessageProcessor.createHttpRequestMessageProcessor);
-    this.requestProcessorFactories.set(_JSONPRequestMessage$createJSONPRequestMessageProcessor.JSONPRequestMessage, _JSONPRequestMessage$createJSONPRequestMessageProcessor.createJSONPRequestMessageProcessor);
+    this.requestProcessorFactories.set(_httpRequestMessage.HttpRequestMessage, _httpRequestMessage.createHttpRequestMessageProcessor);
+    this.requestProcessorFactories.set(_jsonpRequestMessage.JSONPRequestMessage, _jsonpRequestMessage.createJSONPRequestMessageProcessor);
     this.pendingRequests = [];
     this.isRequesting = false;
   }
 
   HttpClient.prototype.configure = function configure(fn) {
-    var builder = new _RequestBuilder.RequestBuilder(this);
+    var builder = new _requestBuilder.RequestBuilder(this);
     fn(builder);
     this.requestTransformers = builder.transformers;
     return this;
   };
 
   HttpClient.prototype.createRequest = function createRequest(url) {
-    var builder = new _RequestBuilder.RequestBuilder(this);
+    var builder = new _requestBuilder.RequestBuilder(this);
 
     if (url) {
       builder.withUrl(url);

--- a/dist/commonjs/http-request-message.js
+++ b/dist/commonjs/http-request-message.js
@@ -1,15 +1,15 @@
 'use strict';
 
-var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
-
 exports.__esModule = true;
 exports.createHttpRequestMessageProcessor = createHttpRequestMessageProcessor;
 
-var _Headers = require('./headers');
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
-var _RequestMessageProcessor = require('./request-message-processor');
+var _headers = require('./headers');
 
-var _timeoutTransformer$credentialsTransformer$progressTransformer$responseTypeTransformer$headerTransformer$contentTransformer = require('./transformers');
+var _requestMessageProcessor = require('./request-message-processor');
+
+var _transformers = require('./transformers');
 
 var HttpRequestMessage = function HttpRequestMessage(method, url, content, headers) {
   _classCallCheck(this, HttpRequestMessage);
@@ -17,12 +17,12 @@ var HttpRequestMessage = function HttpRequestMessage(method, url, content, heade
   this.method = method;
   this.url = url;
   this.content = content;
-  this.headers = headers || new _Headers.Headers();
+  this.headers = headers || new _headers.Headers();
   this.responseType = 'json';
 };
 
 exports.HttpRequestMessage = HttpRequestMessage;
 
 function createHttpRequestMessageProcessor() {
-  return new _RequestMessageProcessor.RequestMessageProcessor(XMLHttpRequest, [_timeoutTransformer$credentialsTransformer$progressTransformer$responseTypeTransformer$headerTransformer$contentTransformer.timeoutTransformer, _timeoutTransformer$credentialsTransformer$progressTransformer$responseTypeTransformer$headerTransformer$contentTransformer.credentialsTransformer, _timeoutTransformer$credentialsTransformer$progressTransformer$responseTypeTransformer$headerTransformer$contentTransformer.progressTransformer, _timeoutTransformer$credentialsTransformer$progressTransformer$responseTypeTransformer$headerTransformer$contentTransformer.responseTypeTransformer, _timeoutTransformer$credentialsTransformer$progressTransformer$responseTypeTransformer$headerTransformer$contentTransformer.headerTransformer, _timeoutTransformer$credentialsTransformer$progressTransformer$responseTypeTransformer$headerTransformer$contentTransformer.contentTransformer]);
+  return new _requestMessageProcessor.RequestMessageProcessor(XMLHttpRequest, [_transformers.timeoutTransformer, _transformers.credentialsTransformer, _transformers.progressTransformer, _transformers.responseTypeTransformer, _transformers.headerTransformer, _transformers.contentTransformer]);
 }

--- a/dist/commonjs/http-response-message.js
+++ b/dist/commonjs/http-response-message.js
@@ -1,12 +1,12 @@
 "use strict";
 
-var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };
+exports.__esModule = true;
 
 var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
-exports.__esModule = true;
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-var _Headers = require("./headers");
+var _headers = require("./headers");
 
 var HttpResponseMessage = (function () {
   function HttpResponseMessage(requestMessage, xhr, responseType, reviver) {
@@ -14,7 +14,7 @@ var HttpResponseMessage = (function () {
 
     this.requestMessage = requestMessage;
     this.statusCode = xhr.status;
-    this.response = xhr.response;
+    this.response = xhr.response || xhr.responseText;
     this.isSuccess = xhr.status >= 200 && xhr.status < 400;
     this.statusText = xhr.statusText;
     this.reviver = reviver;
@@ -22,12 +22,12 @@ var HttpResponseMessage = (function () {
 
     if (xhr.getAllResponseHeaders) {
       try {
-        this.headers = _Headers.Headers.parse(xhr.getAllResponseHeaders());
+        this.headers = _headers.Headers.parse(xhr.getAllResponseHeaders());
       } catch (err) {
         if (xhr.requestHeaders) this.headers = { headers: xhr.requestHeaders };
       }
     } else {
-      this.headers = new _Headers.Headers();
+      this.headers = new _headers.Headers();
     }
 
     var contentType;

--- a/dist/commonjs/index.js
+++ b/dist/commonjs/index.js
@@ -2,27 +2,27 @@
 
 exports.__esModule = true;
 
-var _HttpClient = require('./http-client');
+var _httpClient = require('./http-client');
 
-exports.HttpClient = _HttpClient.HttpClient;
+exports.HttpClient = _httpClient.HttpClient;
 
-var _HttpRequestMessage = require('./http-request-message');
+var _httpRequestMessage = require('./http-request-message');
 
-exports.HttpRequestMessage = _HttpRequestMessage.HttpRequestMessage;
+exports.HttpRequestMessage = _httpRequestMessage.HttpRequestMessage;
 
-var _HttpResponseMessage$mimeTypes = require('./http-response-message');
+var _httpResponseMessage = require('./http-response-message');
 
-exports.HttpResponseMessage = _HttpResponseMessage$mimeTypes.HttpResponseMessage;
-exports.mimeTypes = _HttpResponseMessage$mimeTypes.mimeTypes;
+exports.HttpResponseMessage = _httpResponseMessage.HttpResponseMessage;
+exports.mimeTypes = _httpResponseMessage.mimeTypes;
 
-var _JSONPRequestMessage = require('./jsonp-request-message');
+var _jsonpRequestMessage = require('./jsonp-request-message');
 
-exports.JSONPRequestMessage = _JSONPRequestMessage.JSONPRequestMessage;
+exports.JSONPRequestMessage = _jsonpRequestMessage.JSONPRequestMessage;
 
-var _Headers = require('./headers');
+var _headers = require('./headers');
 
-exports.Headers = _Headers.Headers;
+exports.Headers = _headers.Headers;
 
-var _RequestBuilder = require('./request-builder');
+var _requestBuilder = require('./request-builder');
 
-exports.RequestBuilder = _RequestBuilder.RequestBuilder;
+exports.RequestBuilder = _requestBuilder.RequestBuilder;

--- a/dist/commonjs/jsonp-request-message.js
+++ b/dist/commonjs/jsonp-request-message.js
@@ -1,15 +1,15 @@
 'use strict';
 
-var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
-
 exports.__esModule = true;
 exports.createJSONPRequestMessageProcessor = createJSONPRequestMessageProcessor;
 
-var _Headers = require('./headers');
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
-var _RequestMessageProcessor = require('./request-message-processor');
+var _headers = require('./headers');
 
-var _timeoutTransformer$callbackParameterNameTransformer = require('./transformers');
+var _requestMessageProcessor = require('./request-message-processor');
+
+var _transformers = require('./transformers');
 
 var JSONPRequestMessage = function JSONPRequestMessage(url, callbackParameterName) {
   _classCallCheck(this, JSONPRequestMessage);
@@ -17,7 +17,7 @@ var JSONPRequestMessage = function JSONPRequestMessage(url, callbackParameterNam
   this.method = 'JSONP';
   this.url = url;
   this.content = undefined;
-  this.headers = new _Headers.Headers();
+  this.headers = new _headers.Headers();
   this.responseType = 'jsonp';
   this.callbackParameterName = callbackParameterName;
 };
@@ -79,5 +79,5 @@ var JSONPXHR = (function () {
 })();
 
 function createJSONPRequestMessageProcessor() {
-  return new _RequestMessageProcessor.RequestMessageProcessor(JSONPXHR, [_timeoutTransformer$callbackParameterNameTransformer.timeoutTransformer, _timeoutTransformer$callbackParameterNameTransformer.callbackParameterNameTransformer]);
+  return new _requestMessageProcessor.RequestMessageProcessor(JSONPXHR, [_transformers.timeoutTransformer, _transformers.callbackParameterNameTransformer]);
 }

--- a/dist/commonjs/request-builder.js
+++ b/dist/commonjs/request-builder.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
-
 exports.__esModule = true;
 
-var _join = require('aurelia-path');
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
-var _HttpRequestMessage = require('./http-request-message');
+var _aureliaPath = require('aurelia-path');
 
-var _JSONPRequestMessage = require('./jsonp-request-message');
+var _httpRequestMessage = require('./http-request-message');
+
+var _jsonpRequestMessage = require('./jsonp-request-message');
 
 var RequestBuilder = (function () {
   function RequestBuilder(client) {
@@ -27,7 +27,7 @@ var RequestBuilder = (function () {
   };
 
   RequestBuilder.prototype.send = function send() {
-    var message = this.useJsonp ? new _JSONPRequestMessage.JSONPRequestMessage() : new _HttpRequestMessage.HttpRequestMessage();
+    var message = this.useJsonp ? new _jsonpRequestMessage.JSONPRequestMessage() : new _httpRequestMessage.HttpRequestMessage();
     return this.client.send(message, this.transformers);
   };
 

--- a/dist/commonjs/request-message-processor.js
+++ b/dist/commonjs/request-message-processor.js
@@ -1,25 +1,25 @@
 'use strict';
 
-var _interopRequireDefault = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
-
-var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
-
 exports.__esModule = true;
 
-var _core = require('core-js');
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-var _core2 = _interopRequireDefault(_core);
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
-var _HttpResponseMessage = require('./http-response-message');
+var _coreJs = require('core-js');
 
-var _join$buildQueryString = require('aurelia-path');
+var _coreJs2 = _interopRequireDefault(_coreJs);
+
+var _httpResponseMessage = require('./http-response-message');
+
+var _aureliaPath = require('aurelia-path');
 
 function buildFullUrl(message) {
-  var url = _join$buildQueryString.join(message.baseUrl, message.url),
+  var url = _aureliaPath.join(message.baseUrl, message.url),
       qs;
 
   if (message.params) {
-    qs = _join$buildQueryString.buildQueryString(message.params);
+    qs = _aureliaPath.buildQueryString(message.params);
     url = qs ? '' + url + '?' + qs : url;
   }
 
@@ -57,7 +57,7 @@ var RequestMessageProcessor = (function () {
       }
 
       xhr.onload = function (e) {
-        var response = new _HttpResponseMessage.HttpResponseMessage(message, xhr, message.responseType, message.reviver);
+        var response = new _httpResponseMessage.HttpResponseMessage(message, xhr, message.responseType, message.reviver);
         if (response.isSuccess) {
           resolve(response);
         } else {
@@ -66,7 +66,7 @@ var RequestMessageProcessor = (function () {
       };
 
       xhr.ontimeout = function (e) {
-        reject(new _HttpResponseMessage.HttpResponseMessage(message, {
+        reject(new _httpResponseMessage.HttpResponseMessage(message, {
           response: e,
           status: xhr.status,
           statusText: xhr.statusText
@@ -74,7 +74,7 @@ var RequestMessageProcessor = (function () {
       };
 
       xhr.onerror = function (e) {
-        reject(new _HttpResponseMessage.HttpResponseMessage(message, {
+        reject(new _httpResponseMessage.HttpResponseMessage(message, {
           response: e,
           status: xhr.status,
           statusText: xhr.statusText
@@ -82,7 +82,7 @@ var RequestMessageProcessor = (function () {
       };
 
       xhr.onabort = function (e) {
-        reject(new _HttpResponseMessage.HttpResponseMessage(message, {
+        reject(new _httpResponseMessage.HttpResponseMessage(message, {
           response: e,
           status: xhr.status,
           statusText: xhr.statusText

--- a/dist/es6/http-response-message.js
+++ b/dist/es6/http-response-message.js
@@ -5,7 +5,7 @@ export class HttpResponseMessage {
   constructor(requestMessage, xhr, responseType, reviver){
     this.requestMessage = requestMessage;
     this.statusCode = xhr.status;
-    this.response = xhr.response;
+    this.response = xhr.response || xhr.responseText;
     this.isSuccess = xhr.status >= 200 && xhr.status < 400;
     this.statusText = xhr.statusText;
     this.reviver = reviver;

--- a/dist/system/headers.js
+++ b/dist/system/headers.js
@@ -1,12 +1,12 @@
 System.register([], function (_export) {
-  var _classCallCheck, Headers;
+  var Headers;
+
+  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
   return {
     setters: [],
     execute: function () {
       'use strict';
-
-      _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
 
       Headers = (function () {
         function Headers() {

--- a/dist/system/http-client.js
+++ b/dist/system/http-client.js
@@ -1,5 +1,7 @@
 System.register(['core-js', './headers', './request-builder', './http-request-message', './jsonp-request-message'], function (_export) {
-  var core, Headers, RequestBuilder, HttpRequestMessage, createHttpRequestMessageProcessor, JSONPRequestMessage, createJSONPRequestMessageProcessor, _classCallCheck, HttpClient;
+  var core, Headers, RequestBuilder, HttpRequestMessage, createHttpRequestMessageProcessor, JSONPRequestMessage, createJSONPRequestMessageProcessor, HttpClient;
+
+  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
   function trackRequestStart(client, processor) {
     client.pendingRequests.push(processor);
@@ -36,8 +38,6 @@ System.register(['core-js', './headers', './request-builder', './http-request-me
     }],
     execute: function () {
       'use strict';
-
-      _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
 
       HttpClient = (function () {
         function HttpClient() {

--- a/dist/system/http-request-message.js
+++ b/dist/system/http-request-message.js
@@ -1,7 +1,9 @@
 System.register(['./headers', './request-message-processor', './transformers'], function (_export) {
-  var Headers, RequestMessageProcessor, timeoutTransformer, credentialsTransformer, progressTransformer, responseTypeTransformer, headerTransformer, contentTransformer, _classCallCheck, HttpRequestMessage;
+  var Headers, RequestMessageProcessor, timeoutTransformer, credentialsTransformer, progressTransformer, responseTypeTransformer, headerTransformer, contentTransformer, HttpRequestMessage;
 
   _export('createHttpRequestMessageProcessor', createHttpRequestMessageProcessor);
+
+  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
   function createHttpRequestMessageProcessor() {
     return new RequestMessageProcessor(XMLHttpRequest, [timeoutTransformer, credentialsTransformer, progressTransformer, responseTypeTransformer, headerTransformer, contentTransformer]);
@@ -22,8 +24,6 @@ System.register(['./headers', './request-message-processor', './transformers'], 
     }],
     execute: function () {
       'use strict';
-
-      _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
 
       HttpRequestMessage = function HttpRequestMessage(method, url, content, headers) {
         _classCallCheck(this, HttpRequestMessage);

--- a/dist/system/http-response-message.js
+++ b/dist/system/http-response-message.js
@@ -1,5 +1,9 @@
 System.register(["./headers"], function (_export) {
-  var Headers, _classCallCheck, _createClass, HttpResponseMessage, mimeTypes;
+  var Headers, HttpResponseMessage, mimeTypes;
+
+  var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
   return {
     setters: [function (_headers) {
@@ -8,17 +12,13 @@ System.register(["./headers"], function (_export) {
     execute: function () {
       "use strict";
 
-      _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };
-
-      _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
-
       HttpResponseMessage = (function () {
         function HttpResponseMessage(requestMessage, xhr, responseType, reviver) {
           _classCallCheck(this, HttpResponseMessage);
 
           this.requestMessage = requestMessage;
           this.statusCode = xhr.status;
-          this.response = xhr.response;
+          this.response = xhr.response || xhr.responseText;
           this.isSuccess = xhr.status >= 200 && xhr.status < 400;
           this.statusText = xhr.statusText;
           this.reviver = reviver;

--- a/dist/system/jsonp-request-message.js
+++ b/dist/system/jsonp-request-message.js
@@ -1,7 +1,9 @@
 System.register(['./headers', './request-message-processor', './transformers'], function (_export) {
-  var Headers, RequestMessageProcessor, timeoutTransformer, callbackParameterNameTransformer, _classCallCheck, JSONPRequestMessage, JSONPXHR;
+  var Headers, RequestMessageProcessor, timeoutTransformer, callbackParameterNameTransformer, JSONPRequestMessage, JSONPXHR;
 
   _export('createJSONPRequestMessageProcessor', createJSONPRequestMessageProcessor);
+
+  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
   function createJSONPRequestMessageProcessor() {
     return new RequestMessageProcessor(JSONPXHR, [timeoutTransformer, callbackParameterNameTransformer]);
@@ -18,8 +20,6 @@ System.register(['./headers', './request-message-processor', './transformers'], 
     }],
     execute: function () {
       'use strict';
-
-      _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
 
       JSONPRequestMessage = function JSONPRequestMessage(url, callbackParameterName) {
         _classCallCheck(this, JSONPRequestMessage);

--- a/dist/system/request-builder.js
+++ b/dist/system/request-builder.js
@@ -1,5 +1,7 @@
 System.register(['aurelia-path', './http-request-message', './jsonp-request-message'], function (_export) {
-  var join, HttpRequestMessage, JSONPRequestMessage, _classCallCheck, RequestBuilder;
+  var join, HttpRequestMessage, JSONPRequestMessage, RequestBuilder;
+
+  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
   return {
     setters: [function (_aureliaPath) {
@@ -11,8 +13,6 @@ System.register(['aurelia-path', './http-request-message', './jsonp-request-mess
     }],
     execute: function () {
       'use strict';
-
-      _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
 
       RequestBuilder = (function () {
         function RequestBuilder(client) {

--- a/dist/system/request-message-processor.js
+++ b/dist/system/request-message-processor.js
@@ -1,5 +1,7 @@
 System.register(['core-js', './http-response-message', 'aurelia-path'], function (_export) {
-  var core, HttpResponseMessage, join, buildQueryString, _classCallCheck, RequestMessageProcessor;
+  var core, HttpResponseMessage, join, buildQueryString, RequestMessageProcessor;
+
+  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
   function buildFullUrl(message) {
     var url = join(message.baseUrl, message.url),
@@ -24,8 +26,6 @@ System.register(['core-js', './http-response-message', 'aurelia-path'], function
     }],
     execute: function () {
       'use strict';
-
-      _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
 
       RequestMessageProcessor = (function () {
         function RequestMessageProcessor(xhrType, transformers) {

--- a/src/http-response-message.js
+++ b/src/http-response-message.js
@@ -5,7 +5,7 @@ export class HttpResponseMessage {
   constructor(requestMessage, xhr, responseType, reviver){
     this.requestMessage = requestMessage;
     this.statusCode = xhr.status;
-    this.response = xhr.response;
+    this.response = xhr.response || xhr.responseText;
     this.isSuccess = xhr.status >= 200 && xhr.status < 400;
     this.statusText = xhr.statusText;
     this.reviver = reviver;


### PR DESCRIPTION
When you try to use the http-client to load some data in IE9 it will return undefined for response.content since the response.content property is based on XmlHttpRequest.response

This pull request will fix the issue by using the XmlHttpRequest.responseText if XmlHttpRequest.response is not available.

I have checked out the skeleton navigation and made a changed the welcome controller to load the user from json instead of using the provided values. In IE9 the one which uses http-client from the current master branch will fail to load the welcome view.
 * Will not work in IE9: http://hjortland.org/files/test/aurelia/skeleton-navigation/#/
 * Works in IE9: http://hjortland.org/files/test/aurelia/skeleton-navigation2/#/

Unfortunately I don't have any tests for this issue as I am not sure how we can test for this other than to add IE9 as a browser which we should run tests against.