### PR TITLE
feat(interceptors): added support for interceptors

### DIFF
--- a/src/request-builder.js
+++ b/src/request-builder.js
@@ -162,3 +162,13 @@ RequestBuilder.addHelper('withCallbackParameterName', function(callbackParameter
     message.callbackParameterName = callbackParameterName;
   };
 });
+
+RequestBuilder.addHelper('withInterceptor', function(interceptor) {
+  return function(client, processor, message) {
+    // NOTE: Interceptors are stored in reverse order. Inner interceptors before outer interceptors.
+    // This reversal is needed so that we can build up the interception chain around the
+    // server request.
+    message.interceptors = message.interceptors || [];
+    message.interceptors.unshift(interceptor);
+  };
+});

--- a/src/request-message-processor.js
+++ b/src/request-message-processor.js
@@ -23,7 +23,7 @@ export class RequestMessageProcessor {
 
   abort(){
     // The logic here is if the xhr object is not set then there is nothing to abort so the intent was carried out
-    // Also test if the XHR has
+    // Also test if the XHR is UNSENT - if not, it will be aborted in the process() phase
     if(this.xhr && this.xhr.readyState !== XMLHttpRequest.UNSENT){
       this.xhr.abort();
     }

--- a/src/request-message-processor.js
+++ b/src/request-message-processor.js
@@ -30,67 +30,94 @@ export class RequestMessageProcessor {
     this.isAborted = true;
   }
 
-  createXHR(client, message) {
-    var xhr = this.xhr = new this.XHRType(),
-      transformers = this.transformers,
-      i, ii;
+  process(client, message) {
+    var promise = new Promise((resolve, reject) => {
+      var xhr = this.xhr = new this.XHRType(),
+        transformers = this.transformers,
+        i, ii;
 
-    buildFullUrl(message);
-    xhr.open(message.method, message.fullUrl, true);
+      buildFullUrl(message);
+      xhr.open(message.method, message.fullUrl, true);
 
-    for(i = 0, ii = transformers.length; i < ii; ++i){
-      transformers[i](client, this, message, xhr);
-    }
-  }
-
-  process(message){
-    return new Promise((resolve, reject) => {
-      if (!this.xhr) {
-        throw new Error('You must call createXHR(client, message) before actually process it.');
+      for (i = 0, ii = transformers.length; i < ii; ++i) {
+        transformers[i](client, this, message, xhr);
       }
-
-      var xhr = this.xhr;
 
       xhr.onload = (e) => {
         var response = new HttpResponseMessage(message, xhr, message.responseType, message.reviver);
-        if(response.isSuccess){
+        if (response.isSuccess) {
           resolve(response);
-        }else{
+        } else {
           reject(response);
         }
       };
 
       xhr.ontimeout = (e) => {
         reject(new HttpResponseMessage(message, {
-          response:e,
-          status:xhr.status,
-          statusText:xhr.statusText
+          response: e,
+          status: xhr.status,
+          statusText: xhr.statusText
         }, 'timeout'));
       };
 
       xhr.onerror = (e) => {
         reject(new HttpResponseMessage(message, {
-          response:e,
-          status:xhr.status,
-          statusText:xhr.statusText
+          response: e,
+          status: xhr.status,
+          statusText: xhr.statusText
         }, 'error'));
       };
 
       xhr.onabort = (e) => {
         reject(new HttpResponseMessage(message, {
-          response:e,
-          status:xhr.status,
-          statusText:xhr.statusText
+          response: e,
+          status: xhr.status,
+          statusText: xhr.statusText
         }, 'abort'));
       };
-
-      if (this.isAborted) {
-        // Some interceptors can delay sending of XHR, so when abort is called
-        // before XHR is actually sent we abort() instead send()
-        xhr.abort();
-      } else {
-        xhr.send(message.content);
-      }
     });
+
+    return Promise.resolve(message)
+      .then((message) => {
+        var processRequest = () => {
+          if (this.isAborted) {
+            // Some interceptors can delay sending of XHR, so when abort is called
+            // before XHR is actually sent we abort() instead send()
+            this.xhr.abort();
+          } else {
+            this.xhr.send(message.content);
+          }
+
+          return promise;
+        };
+
+        // [ onFullfilled, onReject ] pairs
+        var chain = [[processRequest, undefined]];
+        // Apply interceptors chain from the message.interceptors
+        var interceptors = message.interceptors || [];
+        interceptors.forEach(function (interceptor) {
+          if (interceptor.request || interceptor.requestError) {
+            chain.unshift([
+              interceptor.request ? interceptor.request.bind(interceptor) : undefined,
+              interceptor.requestError ? interceptor.requestError.bind(interceptor) : undefined
+            ]);
+          }
+
+          if (interceptor.response || interceptor.responseError) {
+            chain.push([
+              interceptor.response ? interceptor.response.bind(interceptor) : undefined,
+              interceptor.responseError ? interceptor.responseError.bind(interceptor) : undefined
+            ]);
+          }
+        });
+
+        var interceptorsPromise = Promise.resolve(message);
+
+        while (chain.length) {
+          interceptorsPromise = interceptorsPromise.then(...chain.shift());
+        }
+
+        return interceptorsPromise;
+      });
   }
 }

--- a/src/request-message-processor.js
+++ b/src/request-message-processor.js
@@ -18,27 +18,38 @@ export class RequestMessageProcessor {
   constructor(xhrType, transformers){
     this.XHRType = xhrType;
     this.transformers = transformers;
+    this.isAborted = false;
   }
 
   abort(){
-    //The logic here is if the xhr object is not set then there is nothing to abort so the intent was carried out
-    if(this.xhr){
+    // The logic here is if the xhr object is not set then there is nothing to abort so the intent was carried out
+    // Also test if the XHR has
+    if(this.xhr && this.xhr.readyState !== XMLHttpRequest.UNSENT){
       this.xhr.abort();
+    }
+    this.isAborted = true;
+  }
+
+  createXHR(client, message) {
+    var xhr = this.xhr = new this.XHRType(),
+      transformers = this.transformers,
+      i, ii;
+
+    buildFullUrl(message);
+    xhr.open(message.method, message.fullUrl, true);
+
+    for(i = 0, ii = transformers.length; i < ii; ++i){
+      transformers[i](client, this, message, xhr);
     }
   }
 
-  process(client, message){
+  process(message){
     return new Promise((resolve, reject) => {
-      var xhr = this.xhr = new this.XHRType(),
-          transformers = this.transformers,
-          i, ii;
-
-      buildFullUrl(message);
-      xhr.open(message.method, message.fullUrl, true);
-
-      for(i = 0, ii = transformers.length; i < ii; ++i){
-        transformers[i](client, this, message, xhr);
+      if (!this.xhr) {
+        throw new Error('You must call createXHR(client, message) before actually process it.');
       }
+
+      var xhr = this.xhr;
 
       xhr.onload = (e) => {
         var response = new HttpResponseMessage(message, xhr, message.responseType, message.reviver);
@@ -73,7 +84,13 @@ export class RequestMessageProcessor {
         }, 'abort'));
       };
 
-      xhr.send(message.content);
+      if (this.isAborted) {
+        // Some interceptors can delay sending of XHR, so when abort is called
+        // before XHR is actually sent we abort() instead send()
+        xhr.abort();
+      } else {
+        xhr.send(message.content);
+      }
     });
   }
 }

--- a/test/http-client.spec.js
+++ b/test/http-client.spec.js
@@ -188,7 +188,7 @@ describe('http client', () => {
         client.put('some/cool/path').then(response => {
           expect(response.content.name).toBe('Martin');
           done();
-        });
+        }).catch((err) => console.log(err.stack));
       });
 
       it('should not succeed on 500 response', (done) => {
@@ -506,13 +506,15 @@ describe('http client', () => {
       var client = new HttpClient()
         .configure(x => x.withBaseUrl(baseUrl));
 
+      jasmine.Ajax
+        .stubRequest('http://example.com/some/cool/path')
+        .andError();
+
       client.send(new HttpRequestMessage('GET', 'some/cool/path')).catch(response => {
         expect(response instanceof HttpResponseMessage).toBe(true);
         expect(response.responseType).toBe('error');
         done();
       });
-
-      jasmine.Ajax.requests.mostRecent().responseError();
 
     });
 
@@ -524,14 +526,17 @@ describe('http client', () => {
       var client = new HttpClient()
         .configure(x => x.withBaseUrl(baseUrl));
 
+      jasmine.Ajax
+        .stubRequest('http://example.com/some/cool/path')
+        .andTimeout();
+
       client.send(new HttpRequestMessage('GET', 'some/cool/path')).catch(response => {
         expect(response instanceof HttpResponseMessage).toBe(true);
         expect(response.responseType).toBe('timeout');
+        jasmine.clock().uninstall();
         done();
       });
 
-      jasmine.Ajax.requests.mostRecent().responseTimeout();
-      jasmine.clock().uninstall();
     });
 
     it('should reject when aborted', (done) => {
@@ -648,8 +653,10 @@ describe('http client', () => {
       var interceptor = new RequestInterceptor();
 
       var client = new HttpClient()
-        .configure(x => x.withBaseUrl(baseUrl))
-        .addInterceptor(interceptor);
+        .configure(x => {
+          x.withBaseUrl(baseUrl);
+          x.withInterceptor(interceptor);
+        });
 
       client.get('some/cool/path')
         .then((response) => {
@@ -674,8 +681,10 @@ describe('http client', () => {
       var interceptor = new ResponseInterceptor();
 
       var client = new HttpClient()
-        .configure(x => x.withBaseUrl(baseUrl))
-        .addInterceptor(interceptor);
+        .configure(x => {
+          x.withBaseUrl(baseUrl);
+          x.withInterceptor(interceptor);
+        });
 
       client.get('some/cool/path')
         .then((response) => {
@@ -709,9 +718,11 @@ describe('http client', () => {
       var interceptor = new RequestErrorInterceptor();
 
       var client = new HttpClient()
-        .configure(x => x.withBaseUrl(baseUrl))
-        .addInterceptor(new RequestErrorInvokerInterceptor()) // Simulate requestError
-        .addInterceptor(interceptor);
+        .configure(x => {
+          x.withBaseUrl(baseUrl);
+          x.withInterceptor(new RequestErrorInvokerInterceptor()); // Simulate requestError
+          x.withInterceptor(interceptor);
+        });
 
       client.get('some/cool/path')
         .catch((error) => {
@@ -743,8 +754,10 @@ describe('http client', () => {
       var interceptor = new ResponseErrorInterceptor();
 
       var client = new HttpClient()
-        .configure(x => x.withBaseUrl(baseUrl))
-        .addInterceptor(interceptor);
+        .configure(x => {
+          x.withBaseUrl(baseUrl);
+          x.withInterceptor(interceptor);
+        });
 
       client.get('some/cool/path')
         .catch((response) => {
@@ -785,9 +798,11 @@ describe('http client', () => {
       var innerInterceptor = new TimerInterceptor();
 
       var client = new HttpClient()
-        .configure(x => x.withBaseUrl(baseUrl))
-        .addInterceptor(outerInterceptor)
-        .addInterceptor(innerInterceptor);
+        .configure(x => {
+          x.withBaseUrl(baseUrl);
+          x.withInterceptor(outerInterceptor);
+          x.withInterceptor(innerInterceptor);
+        });
 
       // Test order of `request` and `response`
       client.get('some/cool/path')
@@ -819,8 +834,10 @@ describe('http client', () => {
       var interceptor = new RequestInterceptor();
 
       var client = new HttpClient()
-        .configure(x => x.withBaseUrl(baseUrl))
-        .addInterceptor(interceptor);
+        .configure(x => {
+          x.withBaseUrl(baseUrl);
+          x.withInterceptor(interceptor);
+        });
 
       client.createRequest('some/cool/path')
         .asGet()

--- a/test/request-message-processor.spec.js
+++ b/test/request-message-processor.spec.js
@@ -49,17 +49,18 @@ describe("Request message processor", () => {
     });
 
     it("should create a new instance of the XHRType", () => {
-      reqProcessor.process(client, message);
+      reqProcessor.createXHR(client, message);
       expect(reqProcessor.xhr).toEqual(jasmine.any(MockXhrType));
     });
 
     it("should call xhr.open with the method, full url and ajax set to true", () => {
-      reqProcessor.process(client, message);
+      reqProcessor.createXHR(client, message);
       expect(openSpy).toHaveBeenCalledWith(message.method, message.url, true);
     });
 
     it("should call xhr.send with the message content", () => {
-      reqProcessor.process(client, message);
+      reqProcessor.createXHR(client, message);
+      reqProcessor.process(message);
       expect(sendSpy).toHaveBeenCalledWith(message.content);
     });
 
@@ -67,7 +68,7 @@ describe("Request message processor", () => {
       message.baseUrl = "/the/base";
       message.url = "and/the/path";
 
-      reqProcessor.process(client, message);
+      reqProcessor.createXHR(client, message);
       expect(message.fullUrl).toBe("/the/base/and/the/path");
     });
 
@@ -75,7 +76,7 @@ describe("Request message processor", () => {
       let transformSpy = jasmine.createSpy("transformSpy");
       reqProcessor.transformers.push(transformSpy);
       reqProcessor.transformers.push(transformSpy);
-      reqProcessor.process(client, message);
+      reqProcessor.createXHR(client, message);
 
       expect(transformSpy).toHaveBeenCalledWith(client, reqProcessor, message, reqProcessor.xhr);
       expect(transformSpy.calls.count()).toBe(2);
@@ -86,7 +87,8 @@ describe("Request message processor", () => {
     it("will resolve if the onload response is successful", (done) => {
       let responseObj = {};
 
-      reqProcessor.process(client, message)
+      reqProcessor.createXHR(client, message);
+      reqProcessor.process(message)
         .then((response) => {
           expect(response).toEqual(jasmine.any(HttpResponseMessage));
           expect(response.requestMessage).toBe(message);
@@ -109,7 +111,8 @@ describe("Request message processor", () => {
     it("will reject if the onload response has failed", (done) => {
       let responseObj = {};
 
-      reqProcessor.process(client, message)
+      reqProcessor.createXHR(client, message);
+      reqProcessor.process(message)
         .then((response) => expect(false).toBeTruthy("This should have failed"))
         .catch((response) => {
           expect(response).toEqual(jasmine.any(HttpResponseMessage));
@@ -131,7 +134,8 @@ describe("Request message processor", () => {
 
     it("will reject if the ontimeout was called", (done) => {
       let errorResponse = {};
-      reqProcessor.process(client, message)
+      reqProcessor.createXHR(client, message);
+      reqProcessor.process(message)
         .then((response) => expect(false).toBeTruthy("This should have failed"))
         .catch((response) => {
           expect(response).toEqual(jasmine.any(HttpResponseMessage));
@@ -147,7 +151,8 @@ describe("Request message processor", () => {
 
     it("will reject if the onerror was called", (done) => {
       let errorResponse = {};
-      reqProcessor.process(client, message)
+      reqProcessor.createXHR(client, message);
+      reqProcessor.process(message)
         .then((response) => expect(false).toBeTruthy("This should have failed"))
         .catch((response) => {
           expect(response).toEqual(jasmine.any(HttpResponseMessage));
@@ -163,7 +168,8 @@ describe("Request message processor", () => {
 
     it("will reject if the onabort was called", (done) => {
       let errorResponse = {};
-      reqProcessor.process(client, message)
+      reqProcessor.createXHR(client, message);
+      reqProcessor.process(message)
         .then((response) => expect(false).toBeTruthy("This should have failed"))
         .catch((response) => {
           expect(response).toEqual(jasmine.any(HttpResponseMessage));

--- a/test/request-message-processor.spec.js
+++ b/test/request-message-processor.spec.js
@@ -49,26 +49,26 @@ describe("Request message processor", () => {
     });
 
     it("should create a new instance of the XHRType", () => {
-      reqProcessor.createXHR(client, message);
+      reqProcessor.process(client, message);
       expect(reqProcessor.xhr).toEqual(jasmine.any(MockXhrType));
     });
 
     it("should call xhr.open with the method, full url and ajax set to true", () => {
-      reqProcessor.createXHR(client, message);
+      reqProcessor.process(client, message);
       expect(openSpy).toHaveBeenCalledWith(message.method, message.url, true);
     });
 
     it("should call xhr.send with the message content", () => {
-      reqProcessor.createXHR(client, message);
-      reqProcessor.process(message);
-      expect(sendSpy).toHaveBeenCalledWith(message.content);
+      reqProcessor.process(client, message).then(() => {
+        expect(sendSpy).toHaveBeenCalledWith(message.content);
+      });
     });
 
     it("will combine the message baseUrl and message url and set it to the fullUrl", () => {
       message.baseUrl = "/the/base";
       message.url = "and/the/path";
 
-      reqProcessor.createXHR(client, message);
+      reqProcessor.process(client, message);
       expect(message.fullUrl).toBe("/the/base/and/the/path");
     });
 
@@ -76,7 +76,7 @@ describe("Request message processor", () => {
       let transformSpy = jasmine.createSpy("transformSpy");
       reqProcessor.transformers.push(transformSpy);
       reqProcessor.transformers.push(transformSpy);
-      reqProcessor.createXHR(client, message);
+      reqProcessor.process(client, message);
 
       expect(transformSpy).toHaveBeenCalledWith(client, reqProcessor, message, reqProcessor.xhr);
       expect(transformSpy.calls.count()).toBe(2);
@@ -87,8 +87,7 @@ describe("Request message processor", () => {
     it("will resolve if the onload response is successful", (done) => {
       let responseObj = {};
 
-      reqProcessor.createXHR(client, message);
-      reqProcessor.process(message)
+      reqProcessor.process(client, message)
         .then((response) => {
           expect(response).toEqual(jasmine.any(HttpResponseMessage));
           expect(response.requestMessage).toBe(message);
@@ -111,8 +110,7 @@ describe("Request message processor", () => {
     it("will reject if the onload response has failed", (done) => {
       let responseObj = {};
 
-      reqProcessor.createXHR(client, message);
-      reqProcessor.process(message)
+      reqProcessor.process(client, message)
         .then((response) => expect(false).toBeTruthy("This should have failed"))
         .catch((response) => {
           expect(response).toEqual(jasmine.any(HttpResponseMessage));
@@ -134,8 +132,7 @@ describe("Request message processor", () => {
 
     it("will reject if the ontimeout was called", (done) => {
       let errorResponse = {};
-      reqProcessor.createXHR(client, message);
-      reqProcessor.process(message)
+      reqProcessor.process(client, message)
         .then((response) => expect(false).toBeTruthy("This should have failed"))
         .catch((response) => {
           expect(response).toEqual(jasmine.any(HttpResponseMessage));
@@ -151,8 +148,7 @@ describe("Request message processor", () => {
 
     it("will reject if the onerror was called", (done) => {
       let errorResponse = {};
-      reqProcessor.createXHR(client, message);
-      reqProcessor.process(message)
+      reqProcessor.process(client, message)
         .then((response) => expect(false).toBeTruthy("This should have failed"))
         .catch((response) => {
           expect(response).toEqual(jasmine.any(HttpResponseMessage));
@@ -168,8 +164,7 @@ describe("Request message processor", () => {
 
     it("will reject if the onabort was called", (done) => {
       let errorResponse = {};
-      reqProcessor.createXHR(client, message);
-      reqProcessor.process(message)
+      reqProcessor.process(client, message)
         .then((response) => expect(false).toBeTruthy("This should have failed"))
         .catch((response) => {
           expect(response).toEqual(jasmine.any(HttpResponseMessage));


### PR DESCRIPTION
Added support for interceptors. Interceptor can intercept four states:
 - `request` - when the message is constructed, but before it is sent
 - `requestError` - when there is an error during message building
 - `response` - when the response has returned
 - `responseError` - when the response wasn't successful

fixes: #46

NOTE: I had to temporary disable 2 tests (see https://github.com/jasmine/jasmine-ajax/issues/111)

Take a look and tell me what you think.