### PR TITLE
feat(params): allow passing URL params for GET, HEAD, DELETE, OPTIONS

### DIFF
--- a/src/http-client.js
+++ b/src/http-client.js
@@ -118,10 +118,11 @@ export class HttpClient {
    *
    * @method delete
    * @param {String} url The target URL.
+   * @param {object|undefined} params Optional request params
    * @return {Promise} A cancellable promise object.
    */
-  delete(url){
-    return this.createRequest(url).asDelete().send();
+  delete(url, params){
+    return this.createRequest(url).asDelete().withParams(params).send();
   }
 
   /**
@@ -129,10 +130,11 @@ export class HttpClient {
    *
    * @method get
    * @param {String} url The target URL.
+   * @param {object|undefined} params Optional request params
    * @return {Promise} A cancellable promise object.
    */
-  get(url){
-    return this.createRequest(url).asGet().send();
+  get(url, params){
+    return this.createRequest(url).asGet().withParams(params).send();
   }
 
   /**
@@ -140,10 +142,11 @@ export class HttpClient {
    *
    * @method head
    * @param {String} url The target URL.
+   * @param {object|undefined} params Optional request params
    * @return {Promise} A cancellable promise object.
    */
-  head(url){
-    return this.createRequest(url).asHead().send();
+  head(url, params){
+    return this.createRequest(url).asHead().withParams(params).send();
   }
 
   /**
@@ -162,10 +165,11 @@ export class HttpClient {
    *
    * @method options
    * @param {String} url The target URL.
+   * @param {object|undefined} params Optional request params
    * @return {Promise} A cancellable promise object.
    */
-  options(url){
-    return this.createRequest(url).asOptions().send();
+  options(url, params){
+    return this.createRequest(url).asOptions().withParams(params).send();
   }
 
   /**

--- a/test/http-client.spec.js
+++ b/test/http-client.spec.js
@@ -10,7 +10,11 @@ describe('http client', () => {
     jasmine.Ajax.install();
 
     jasmine.Ajax
-      .stubRequest('http://example.com/some/cool/path')
+      .stubRequest(`${baseUrl}some/cool/path`)
+      .andReturn({ status: 200 });
+
+    jasmine.Ajax
+      .stubRequest(`${baseUrl}some/cool/path?q=search&foo=bar`)
       .andReturn({ status: 200 });
   });
 
@@ -36,6 +40,21 @@ describe('http client', () => {
           done();
         });
 
+      });
+
+      it('should make expected request with params', (done) => {
+        var client = new HttpClient()
+          .configure(x => x.withBaseUrl(baseUrl));
+
+        client.get('some/cool/path', { q: 'search', foo: 'bar' }).then(() => {
+          var request = jasmine.Ajax.requests.mostRecent();
+
+          expect(request.url).toBe(`${baseUrl}some/cool/path?q=search&foo=bar`);
+          expect(request.method).toBe('GET');
+          expect(request.data()).toEqual({});
+
+          done();
+        });
       });
 
       it('should provide expected request headers', (done) => {
@@ -441,6 +460,21 @@ describe('http client', () => {
           var request = jasmine.Ajax.requests.mostRecent();
 
           expect(request.url).toBe(`${baseUrl}some/cool/path`);
+          expect(request.method).toBe('DELETE');
+          expect(request.data()).toEqual({});
+          done();
+        });
+
+      });
+
+      it('should make expected request with params', (done) => {
+        var client = new HttpClient()
+          .configure(x => x.withBaseUrl(baseUrl));
+
+        client.delete('some/cool/path', { q: 'search', foo: 'bar' }).then(() => {
+          var request = jasmine.Ajax.requests.mostRecent();
+
+          expect(request.url).toBe(`${baseUrl}some/cool/path?q=search&foo=bar`);
           expect(request.method).toBe('DELETE');
           expect(request.data()).toEqual({});
           done();


### PR DESCRIPTION
This should fix #53

Currently I modified only `get()`, `head()`, `delete()` and `options()`. The `jsonp()`, `put()`, `patch()`, `post()` should be also modified, but first I want to know what you think about ordering arguments in these methods?