### PR TITLE
fix(http-client): Use correct import for core-js

### DIFF
--- a/src/http-client.js
+++ b/src/http-client.js
@@ -1,4 +1,4 @@
-import core from 'core-js';
+import * as core from 'core-js';
 import {Headers} from './headers';
 import {RequestBuilder} from './request-builder';
 import {HttpRequestMessage,createHttpRequestMessageProcessor} from './http-request-message';

--- a/src/request-message-processor.js
+++ b/src/request-message-processor.js
@@ -1,4 +1,4 @@
-import core from 'core-js';
+import * as core from 'core-js';
 import {HttpResponseMessage} from './http-response-message';
 import {join, buildQueryString} from 'aurelia-path';
 


### PR DESCRIPTION
We were previously using `import core from core-js` which generates d.ts that do not match the corejs d.ts. This is now updated to `import * as core 'core-js'`, which resolves TypeScript compilation warnings.

closes aurelia/framework#177