### PR TITLE
fix(XHR interface): change the return types of abort and send to void

### DIFF
--- a/dist/amd/aurelia-http-client.d.ts
+++ b/dist/amd/aurelia-http-client.d.ts
@@ -14,8 +14,8 @@ declare module 'aurelia-http-client' {
     ontimeout: Function;
     onerror: Function;
     onabort: Function;
-    abort(): undefined;
-    send(content?: any): undefined;
+    abort(): void;
+    send(content?: any): void;
   }
   export interface XHRTransformer {
   }


### PR DESCRIPTION
fix(XHR interface): change the return types of abort and send to void

The return types of the abort and send methods were declared ```undefined``` which is not a valid TypeScript type. Inferring from related types, e.g. ```JSONPXHR```, change them to ```void```.