### PR TITLE
Updated karma-jspm dependencies

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,21 +1,19 @@
 System.config({
-  "transpiler": "babel",
-  "babelOptions": {
+  defaultJSExtensions: true,
+  transpiler: "babel",
+  babelOptions: {
     "optional": [
       "runtime",
       "es7.decorators"
     ]
   },
-  "paths": {
-    "*": "*.js",
-    "github:*": "jspm_packages/github/*.js",
+  paths: {
+    "github:*": "jspm_packages/github/*",
     "aurelia-http-client/*": "dist/system/*.js",
-    "npm:*": "jspm_packages/npm/*.js"
-  }
-});
+    "npm:*": "jspm_packages/npm/*"
+  },
 
-System.config({
-  "map": {
+  map: {
     "aurelia-path": "github:aurelia/path@0.8.1",
     "babel": "npm:babel-core@5.1.13",
     "babel-runtime": "npm:babel-runtime@5.1.13",
@@ -23,12 +21,8 @@ System.config({
     "github:jspm/nodelibs-process@0.1.1": {
       "process": "npm:process@0.10.1"
     },
-    "npm:core-js@0.4.10": {
-      "process": "github:jspm/nodelibs-process@0.1.1"
-    },
     "npm:core-js@0.9.5": {
       "process": "github:jspm/nodelibs-process@0.1.1"
     }
   }
 });
-

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "karma-coverage": "^0.3.1",
     "karma-jasmine": "^0.3.5",
     "karma-jasmine-ajax": "git://github.com/martingust/karma-jasmine-ajax.git",
-    "karma-jspm": "^1.1.5",
+    "karma-jspm": "^2.0.1-beta.2",
     "karma-source-map-support": "^1.1.0",
     "object.assign": "^1.0.3",
     "require-dir": "^0.1.0",


### PR DESCRIPTION
It also updates the `config.js`. I'm not sure if you like using `defaultJSExtensions: true`. This is how `jspm-cli` generated the config.js after updating the karma-jspm. Also I have jspm@beta installed. 
With this I have my test running just fine