### PR TITLE
Updated "configure" signature for TS completion

### DIFF
--- a/src/http-client.js
+++ b/src/http-client.js
@@ -40,7 +40,7 @@ export class HttpClient {
    * Configure this HttpClient with default settings to be used by all requests.
    * @param fn A function that takes a RequestBuilder as an argument.
    */
-  configure(fn: Function): HttpClient {
+  configure(fn: (builder: RequestBuilder) => RequestBuilder): HttpClient {
     let builder = new RequestBuilder(this);
     fn(builder);
     this.requestTransformers = builder.transformers;


### PR DESCRIPTION
Once #71  gets fixed, this will be really helpful when working with TS - no more need to specify callback parameter type explicitly 