### PR TITLE
Ignore baseUrl with absolute URIs

### DIFF
--- a/src/request-message.js
+++ b/src/request-message.js
@@ -11,7 +11,7 @@ export class RequestMessage {
   }
 
   buildFullUrl(): string {
-    let url = join(this.baseUrl, this.url);
+    let url = this.url.match(/^(http(s?))\:\/\//i) ? this.url : join(this.baseUrl, this.url);
 
     if (this.params) {
       let qs = buildQueryString(this.params);

--- a/src/request-message.js
+++ b/src/request-message.js
@@ -11,7 +11,8 @@ export class RequestMessage {
   }
 
   buildFullUrl(): string {
-    let url = this.url.match(/^(http(s?))\:\/\//i) ? this.url : join(this.baseUrl, this.url);
+    let absoluteUrl = /^([a-z][a-z0-9+\-.]*:)?\/\//i;
+    let url = absoluteUrl.test(this.url) ? this.url : join(this.baseUrl, this.url);
 
     if (this.params) {
       let qs = buildQueryString(this.params);


### PR DESCRIPTION
When using a configured instance of `http-client` with a `baseUrl`, using the shortcut methods (e.g. `get(url)`) won't work with absolute URIs, where in many cases one should deal with absolute URIs from the same API (e.g. HTTP `Link` header fields).
The PR adds this support ignoring the `baseUrl` with absolute URIs, using a `RegExp` to have the match case-insensitive.