### PR TITLE
fix(http-client): declare headers property

### DIFF
--- a/src/http-response-message.js
+++ b/src/http-response-message.js
@@ -39,6 +39,11 @@ export class HttpResponseMessage {
   * The mime type of the response.
   */
   mimeType: string;
+  
+  /**
+  * The headers received with the response.
+  */
+  headers: Headers;
 
   /**
   * Creates an instance of HttpResponseMessage.


### PR DESCRIPTION
To be able to access the `headers` property in TypeScript project, the property must be declared, but `HttpResponseMessage` initialises it in its constructor. This PR fixes this, declaring the property and its type.