### PR TITLE
fix(http-client): declare replacer property

### DIFF
--- a/src/http-request-message.js
+++ b/src/http-request-message.js
@@ -14,6 +14,12 @@ import {
 * Represents an HTTP request message.
 */
 export class HttpRequestMessage extends RequestMessage {
+  
+  /**
+  * A replacer function to use in transforming the content.
+  */
+  replacer: (key: string, value: any) => any;
+  
   /**
   * Creates an instance of HttpRequestMessage.
   * @param method The http method.


### PR DESCRIPTION
On a TypeScript project, in the need to have an `Interceptor` to transform content on every request/response one can set the `HttpResponseMessage.reviver` property with a custom reviver function, but setting `HttpRequestMessage.replacer` throws a compiler error: `Property 'replacer' does not exist on type 'HttpRequestMessage'`.
```javascript
export class MessageInterceptor implements Interceptor {

  request(message: HttpRequestMessage): HttpRequestMessage {
    message.replacer = myReplacerFunc;
    // TS Error Property 'replacer' does not exist on type 'HttpRequestMessage'
    return message;
  }

  response(message: HttpResponseMessage): HttpResponseMessage {
    message.reviver = myReviverFunc;
    return message;
  }

}
```
This PR adds the `replacer` property to `HttpRequestMessage`.