### PR TITLE
Update request-message.js

### DIFF
--- a/src/request-message.js
+++ b/src/request-message.js
@@ -55,7 +55,7 @@ export class RequestMessage {
 
     if (this.params) {
       let qs = buildQueryString(this.params);
-      url = qs ? `${url}?${qs}` : url;
+      url = qs ? url + (this.url.indexOf('?') < 0 ? '?' : '&') + qs : url;
     }
 
     return url;


### PR DESCRIPTION
Applied Fix from rebrown547 for buildFullUrl.

Breeze Query Fails when a parameter object is included. When there are existing parameters, the parameter prefix should be '&' not '?'.

In 1.0.0-Beta.1 the following code RequestMessage.prototype.buildFullUrl should be :
if (this.params) {
var qs = _aureliaPath.buildQueryString(this.params);
url = qs ? url + (this.url.indexOf('?') < 0 ? '?' : '&') + qs : url;
}