### PR TITLE
aurelia-pal.PLATFORM has property global

### DIFF
--- a/src/http-request-message.js
+++ b/src/http-request-message.js
@@ -38,7 +38,7 @@ export class HttpRequestMessage extends RequestMessage {
 * @return A processor instance for HTTP request messages.
 */
 export function createHttpRequestMessageProcessor(): RequestMessageProcessor {
-  return new RequestMessageProcessor(PLATFORM.XMLHttpRequest, [
+  return new RequestMessageProcessor(PLATFORM.global.XMLHttpRequest, [
     timeoutTransformer,
     credentialsTransformer,
     progressTransformer,


### PR DESCRIPTION
While learning about how to work with Aurelia framework by following Pluralsight Tutorial on "Aurelia Fundamentals" I came across an issue of getting an internal error inside the "aurelia-http-client". The error was 
` _this.XHRType() is not a function`
the cause of the error was due to `PLATFORM.XMLHttpRequest` retrning `undefined` on this line
``` javascript
return new RequestMessageProcessor(PLATFORM.XMLHttpRequest, [
```
found in https://github.com/aurelia/http-client/blob/master/src/http-request-message.js#L41

while debugging through this issue I have discovered that the `aurelia-pal` library had `PLATFORM` namespace defined and a number of it's properties were doubly defined on the `PLATFORM.global` namespace, and in my case during babel transpiling all the properties were availble on the `PLATFORM.global` namespace and there was no getter for `XMLHttpRequest` on the `PLATFORM` namespace.

The reason why I had this error is due to the fact that, when I started my repository and install aurelia packages with jspm, I pulled the `beta` version of all packages and a couple of days later I did `jspm install aurelia-http-client` which pulled the `rc` version of the library (`aurelia-http-client@1.0.0-rc.1.0.0`). 

To prevent other developers getting into an odd state between releases, I would suggest pulling all the properties defined on the `PLATFORM` interface from the `PLATFORM.global`.

