### PR TITLE
Fixed issue where the response is empty

### DIFF
--- a/src/http-response-message.js
+++ b/src/http-response-message.js
@@ -92,8 +92,8 @@ export class HttpResponseMessage {
         return this._content;
       }
 
-      if (this.response === undefined || this.response === null) {
-        this._content = this.response;
+      if (this.response === undefined || this.response === null || this.response === '') {
+        this._content = null;
         return this._content;
       }
 


### PR DESCRIPTION
I have an existing API which for some requests doesn't return anything in the message body.  Just sets the https status and the reason.  These cause the Http-Client to trip over and throw exceptions when trying to parse and empty string as json.

This fixes the issue here https://github.com/aurelia/http-client/issues/131