### PR TITLE
doc(interceptors): fix error handler typings

### DIFF
--- a/src/request-builder.js
+++ b/src/request-builder.js
@@ -13,7 +13,7 @@ interface Interceptor {
 	/**
 	 * Intercepts a response error.
 	 */
-	responseError?: (error: Error) => HttpResponseMessage | Promise<HttpResponseMessage>;
+	responseError?: (error: HttpResponseMessage) => HttpResponseMessage | Promise<HttpResponseMessage>;
 	/**
 	 * Intercepts the request.
 	 */
@@ -21,7 +21,7 @@ interface Interceptor {
 	/**
 	 * Intercepts a request error.
 	 */
-	requestError?: (error: Error) => HttpResponseMessage | Promise<HttpResponseMessage>;
+	requestError?: (error: Error) => RequestMessage | Promise<RequestMessage>;
 }
 
 /**


### PR DESCRIPTION
Both resolve and reject in XHR request processing are called with HttpResponseMessage.

In requestError, parameter type is anything that previous interceptor throws, but response must be RequestMessage to allow continue processing (unless another error is thrown).