### PR TITLE
fix(http-response-message): handle empty responses

### DIFF
--- a/src/http-response-message.js
+++ b/src/http-response-message.js
@@ -101,7 +101,7 @@ export class HttpResponseMessage {
         return this._content;
       }
 
-      if (this.response === undefined || this.response === null) {
+      if (this.response === undefined || this.response === null || this.response == '') {
         this._content = this.response;
         return this._content;
       }

--- a/test/http-response-message.spec.js
+++ b/test/http-response-message.spec.js
@@ -109,6 +109,11 @@ describe("HttpResponseMessage", () => {
       expect(httpResponse.content).toBeNull();
     });
 
+    it("will return a blank string if response is blank", () => {
+      let httpResponse = new HttpResponseMessage(null, {response: '',responseText:''});
+      expect(httpResponse.content).toBe('');
+    });
+
     it("will JSON.parse if the response type is 'json'", () => {
       let response = {}, reviver = {}, content = {};
       let parseSpy = spyOn(JSON, 'parse').and.returnValue(content);


### PR DESCRIPTION
In the senerio where an API returns a 204 No Content we don't try to
JSON parse and empty string.

this is also the same exact commit @maverix made, but added a test.. it didn't break any existing tests...
