### PR TITLE
chore(dts): Make reviver function optional

### DIFF
--- a/src/http-response-message.js
+++ b/src/http-response-message.js
@@ -55,9 +55,9 @@ export class HttpResponseMessage {
   * @param requestMessage The request message that resulted in this response.
   * @param xhr The XHR instance that made the request.
   * @param responseType The type of the response.
-  * @param reviver A reviver function to use in transforming the content.
+  * @param reviver? A reviver function to use in transforming the content.
   */
-  constructor(requestMessage: RequestMessage, xhr: XHR, responseType: string, reviver: (key: string, value: any) => any) {
+  constructor(requestMessage: RequestMessage, xhr: XHR, responseType: string, reviver?: (key: string, value: any) => any) {
     this.requestMessage = requestMessage;
     this.statusCode = xhr.status;
     this.response = xhr.response || xhr.responseText;


### PR DESCRIPTION
Allows creating HttpResponseMessages in tests for instance without
specifying a reviver.